### PR TITLE
Encryption-key obliteration: verify, record, and a wipe-only command

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,11 @@ If you are on windows, next run `restorekit setup-driver` to install our custom 
 Then run:
 
 ```sh
-sudo restorekit erase
+sudo restorekit restore
 # or by eid
-sudo restorekit erase --ecid 0xc60a812345678 
+sudo restorekit restore --ecid 0xc60a812345678 
 # or with no prompts
-sudo restorekit erase --yes
+sudo restorekit restore --yes
 
 # or use it to just enable dfu (macOS Only):
 sudo restorekit dfu

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -441,13 +441,17 @@ pub async fn restore(
     app: AppHandle,
     ipsw: String,
     serial: String,
-    revive: bool,
+    mode: String,
 ) -> Result<(), String> {
     tauri::async_runtime::spawn_blocking(move || {
         let (_, _, ecid, _, _) =
             parse_serial(&serial).ok_or_else(|| "could not parse device serial".to_string())?;
         let cache = firmware::default_cache_dir().ok();
-        let mode = if revive { Mode::Revive } else { Mode::Erase };
+        let mode = match mode.as_str() {
+            "revive" => Mode::Revive,
+            "obliterate" => Mode::Obliterate,
+            _ => Mode::Erase,
+        };
         restore::restore(
             std::path::Path::new(&ipsw),
             ecid,

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -458,6 +458,7 @@ pub async fn restore(
                 let _ = app.emit("progress", &event);
             },
         )
+        .map(|_| ())
         .map_err(|e| e.to_string())
     })
     .await

--- a/apps/desktop/src-tauri/src/restores.rs
+++ b/apps/desktop/src-tauri/src/restores.rs
@@ -36,6 +36,11 @@ pub struct JobView {
     /// Erase-restore key-wipe verdict once known (`confirmed` | `failed` |
     /// `unconfirmed` | `not_applicable`); `None` until the worker reports it.
     pub obliteration: Option<String>,
+    /// Full checkpoint messages the device reported, each a JSON array of
+    /// strings: `checkpoints_json` is the compact JSON view, `checkpoints_raw`
+    /// the exact plists as XML. `None` until reported.
+    pub checkpoints_json: Option<String>,
+    pub checkpoints_raw: Option<String>,
 }
 
 struct Job {
@@ -167,6 +172,8 @@ async fn run_job(
     let mut lines = BufReader::new(stdout).lines();
     let mut failure: Option<String> = None;
     let mut obliteration: Option<String> = None;
+    let mut checkpoints_json: Option<String> = None;
+    let mut checkpoints_raw: Option<String> = None;
 
     while let Ok(Some(line)) = lines.next_line().await {
         let Ok(v) = serde_json::from_str::<serde_json::Value>(&line) else {
@@ -212,6 +219,16 @@ async fn run_job(
                     ),
                 );
             }
+            Some("checkpoints") => {
+                // Store each array (of full checkpoint plists) verbatim as a JSON
+                // string for the history record.
+                if let Some(j) = v.get("json").filter(|a| a.as_array().is_some_and(|a| !a.is_empty())) {
+                    checkpoints_json = Some(j.to_string());
+                }
+                if let Some(r) = v.get("raw").filter(|a| a.as_array().is_some_and(|a| !a.is_empty())) {
+                    checkpoints_raw = Some(r.to_string());
+                }
+            }
             Some("error") => {
                 failure = Some(
                     v.get("message")
@@ -227,10 +244,14 @@ async fn run_job(
     let ok = matches!(child.wait().await, Ok(s) if s.success());
     // Record the wipe verdict on the job before the terminal update so the UI's
     // "done" snapshot (and the history entry it writes) carries it.
-    if obliteration.is_some() {
+    if obliteration.is_some() || checkpoints_json.is_some() || checkpoints_raw.is_some() {
         let mut g = inner.lock().await;
         if let Some(job) = g.jobs.get_mut(&id) {
-            job.view.obliteration = obliteration;
+            if obliteration.is_some() {
+                job.view.obliteration = obliteration;
+            }
+            job.view.checkpoints_json = checkpoints_json;
+            job.view.checkpoints_raw = checkpoints_raw;
         }
     }
     if ok && failure.is_none() {
@@ -274,6 +295,8 @@ pub async fn enqueue_restore(
             progress: 0.0,
             message: String::new(),
             obliteration: None,
+            checkpoints_json: None,
+            checkpoints_raw: None,
         };
         g.jobs.insert(
             id,

--- a/apps/desktop/src-tauri/src/restores.rs
+++ b/apps/desktop/src-tauri/src/restores.rs
@@ -33,6 +33,9 @@ pub struct JobView {
     pub step: String,
     pub progress: f32,
     pub message: String,
+    /// Erase-restore key-wipe verdict once known (`confirmed` | `failed` |
+    /// `unconfirmed` | `not_applicable`); `None` until the worker reports it.
+    pub obliteration: Option<String>,
 }
 
 struct Job {
@@ -163,6 +166,7 @@ async fn run_job(
     let stdout = child.stdout.take().expect("piped stdout");
     let mut lines = BufReader::new(stdout).lines();
     let mut failure: Option<String> = None;
+    let mut obliteration: Option<String> = None;
 
     while let Ok(Some(line)) = lines.next_line().await {
         let Ok(v) = serde_json::from_str::<serde_json::Value>(&line) else {
@@ -183,6 +187,31 @@ async fn run_job(
                 let l = v.get("line").and_then(|x| x.as_str()).unwrap_or("");
                 emit_log(&app, id, level, l);
             }
+            Some("obliteration") => {
+                let status = v.get("status").and_then(|x| x.as_str()).unwrap_or("");
+                if !status.is_empty() {
+                    // Keep a confirmed/failed verdict over a later unconfirmed one
+                    // (a retry that fails before re-reaching the wipe checkpoint).
+                    let strong = status == "confirmed" || status == "failed";
+                    if obliteration.is_none() || strong {
+                        obliteration = Some(status.to_string());
+                    }
+                }
+                let detail = v.get("detail").and_then(|x| x.as_str()).unwrap_or("");
+                emit_log(
+                    &app,
+                    id,
+                    if status == "failed" { 0 } else { 2 },
+                    &format!(
+                        "encryption-key obliteration: {status}{}",
+                        if detail.is_empty() {
+                            String::new()
+                        } else {
+                            format!(" ({detail})")
+                        }
+                    ),
+                );
+            }
             Some("error") => {
                 failure = Some(
                     v.get("message")
@@ -196,6 +225,14 @@ async fn run_job(
     }
 
     let ok = matches!(child.wait().await, Ok(s) if s.success());
+    // Record the wipe verdict on the job before the terminal update so the UI's
+    // "done" snapshot (and the history entry it writes) carries it.
+    if obliteration.is_some() {
+        let mut g = inner.lock().await;
+        if let Some(job) = g.jobs.get_mut(&id) {
+            job.view.obliteration = obliteration;
+        }
+    }
     if ok && failure.is_none() {
         set_status(&inner, &app, id, "done", "restored", Some(100.0), "").await;
     } else {
@@ -236,6 +273,7 @@ pub async fn enqueue_restore(
             step: "queued".into(),
             progress: 0.0,
             message: String::new(),
+            obliteration: None,
         };
         g.jobs.insert(
             id,

--- a/apps/desktop/src-tauri/src/restores.rs
+++ b/apps/desktop/src-tauri/src/restores.rs
@@ -43,7 +43,8 @@ struct Job {
     abort: Option<AbortHandle>,
     // Retained so a job can be restarted.
     ipsw: String,
-    revive: bool,
+    // "restore" | "revive" | "obliterate".
+    mode: String,
 }
 
 #[derive(Default)]
@@ -130,7 +131,7 @@ async fn run_job(
     id: u64,
     ipsw: String,
     ecid: String,
-    revive: bool,
+    mode: String,
 ) {
     let _permit = match sem.acquire_owned().await {
         Ok(p) => p,
@@ -147,10 +148,9 @@ async fn run_job(
             return;
         }
     };
-    let mode = if revive { "revive" } else { "erase" };
     let mut child = match tokio::process::Command::new(exe)
         .arg(crate::worker::RESTORE_WORKER_ARG)
-        .args(["--ipsw", &ipsw, "--ecid", &ecid, "--mode", mode])
+        .args(["--ipsw", &ipsw, "--ecid", &ecid, "--mode", &mode])
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
         .kill_on_drop(true)
@@ -250,7 +250,7 @@ pub async fn enqueue_restore(
     ipsw: String,
     ecid: String,
     name: String,
-    revive: bool,
+    mode: String,
 ) -> Result<u64, String> {
     let inner = restores.inner.clone();
     let sem = restores.sem.clone();
@@ -281,7 +281,7 @@ pub async fn enqueue_restore(
                 view: view.clone(),
                 abort: None,
                 ipsw: ipsw.clone(),
-                revive,
+                mode: mode.clone(),
             },
         );
         g.order.push(id);
@@ -291,7 +291,7 @@ pub async fn enqueue_restore(
 
     let handle = restores
         .rt
-        .spawn(run_job(app, inner.clone(), sem, id, ipsw, ecid, revive));
+        .spawn(run_job(app, inner.clone(), sem, id, ipsw, ecid, mode));
     if let Some(job) = inner.lock().await.jobs.get_mut(&id) {
         job.abort = Some(handle.abort_handle());
     }
@@ -330,7 +330,7 @@ pub async fn restart_restore(
     let inner = restores.inner.clone();
     let sem = restores.sem.clone();
 
-    let (ipsw, ecid, revive) = {
+    let (ipsw, ecid, mode) = {
         let mut g = inner.lock().await;
         let Some(job) = g.jobs.get_mut(&id) else {
             return Err("no such job".into());
@@ -344,12 +344,12 @@ pub async fn restart_restore(
         job.view.message.clear();
         let view = job.view.clone();
         emit_update(&app, &view);
-        (job.ipsw.clone(), job.view.ecid.clone(), job.revive)
+        (job.ipsw.clone(), job.view.ecid.clone(), job.mode.clone())
     };
 
     let handle = restores
         .rt
-        .spawn(run_job(app, inner.clone(), sem, id, ipsw, ecid, revive));
+        .spawn(run_job(app, inner.clone(), sem, id, ipsw, ecid, mode));
     if let Some(job) = inner.lock().await.jobs.get_mut(&id) {
         job.abort = Some(handle.abort_handle());
     }

--- a/apps/desktop/src-tauri/src/worker.rs
+++ b/apps/desktop/src-tauri/src/worker.rs
@@ -36,10 +36,10 @@ pub fn maybe_run() -> bool {
             None => s.parse().ok(),
         }
     });
-    let mode = if get("--mode").as_deref() == Some("revive") {
-        Mode::Revive
-    } else {
-        Mode::Erase
+    let mode = match get("--mode").as_deref() {
+        Some("revive") => Mode::Revive,
+        Some("obliterate") => Mode::Obliterate,
+        _ => Mode::Erase,
     };
     let cache = get("--cache-dir").map(PathBuf::from);
 

--- a/apps/desktop/src-tauri/src/worker.rs
+++ b/apps/desktop/src-tauri/src/worker.rs
@@ -57,7 +57,7 @@ pub fn maybe_run() -> bool {
     });
 
     match result {
-        Ok(()) => std::process::exit(0),
+        Ok(_) => std::process::exit(0),
         Err(e) => {
             emit_error(&e.to_string());
             std::process::exit(1);

--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -506,6 +506,8 @@
           status: j.status === "done" ? "restored" : "restore_failed",
           timestamp_rfc3339: new Date().toISOString(),
           obliteration: j.obliteration ?? null,
+          checkpoints_json: j.checkpoints_json ?? null,
+          checkpoints_raw: j.checkpoints_raw ?? null,
         })
         .then(loadHistory)
         .catch(() => {});

--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -483,7 +483,11 @@
       jobEnd[j.id] = Date.now();
     }
     // Log a finished restore to history once (best-effort; enrich from devices).
-    if (j.status === "done" && historyEnabled && !recordedJobs.has(j.id)) {
+    // Also log a failed restore when the key was still obliterated, so a wipe
+    // that completed before a later failure is captured for the refurb audit.
+    const wiped = j.obliteration === "confirmed" || j.obliteration === "failed";
+    const shouldRecord = j.status === "done" || (j.status === "failed" && wiped);
+    if (shouldRecord && historyEnabled && !recordedJobs.has(j.id)) {
       recordedJobs.add(j.id);
       const d = devices.find((x) => x.ecid === j.ecid);
       void api
@@ -493,8 +497,9 @@
           model_identifier: d?.identifier ?? null,
           name: j.name,
           mode: d?.mode ?? "restore",
-          status: "restored",
+          status: j.status === "done" ? "restored" : "restore_failed",
           timestamp_rfc3339: new Date().toISOString(),
+          obliteration: j.obliteration ?? null,
         })
         .then(loadHistory)
         .catch(() => {});

--- a/apps/desktop/src/App.svelte
+++ b/apps/desktop/src/App.svelte
@@ -118,7 +118,13 @@
   let firmware = $state<Firmware | null>(null);
   let osVersion = $state("");
   let ipswPath = $state<string | null>(null);
-  let revive = $state(false);
+  type RestoreMode = "restore" | "revive" | "obliterate";
+  let restoreMode = $state<RestoreMode>("restore");
+  const RESTORE_MODE_LABEL: Record<RestoreMode, string> = {
+    restore: "Erase & restore",
+    revive: "Revive",
+    obliterate: "Obliterate",
+  };
   let busy = $state(""); // short-lived status for trigger/reboot
   let error = $state("");
   let confirming = $state(false);
@@ -960,7 +966,7 @@
       if (!ipsw) throw new Error("no firmware to restore");
       // Hand the restore to the parallel job queue (its own process). It shows up
       // live in the roster and detail; several can run at once.
-      await api.enqueueRestore(ipsw, active.ecid, active.name, revive);
+      await api.enqueueRestore(ipsw, active.ecid, active.name, restoreMode);
       api.cacheInfo().then((v) => (cache = v)).catch(() => {});
       selectedKey = active.ecid || active.serial;
       logFollow = true;
@@ -1218,14 +1224,18 @@
               <div class="opt">
                 <span class="ok-label">Mode</span>
                 <span class="seg">
-                  <button class="segbtn" class:on={!revive} onclick={() => (revive = false)}>Erase &amp; restore</button>
-                  <button class="segbtn" class:on={revive} onclick={() => (revive = true)}>Revive</button>
+                  <button class="segbtn" class:on={restoreMode === "restore"} onclick={() => (restoreMode = "restore")}>Erase &amp; restore</button>
+                  <button class="segbtn" class:on={restoreMode === "revive"} onclick={() => (restoreMode = "revive")}>Revive</button>
+                  <button class="segbtn" class:on={restoreMode === "obliterate"} onclick={() => (restoreMode = "obliterate")}>Obliterate</button>
                 </span>
               </div>
+              {#if restoreMode === "obliterate"}
+                <p class="opt-note">Destroys the encryption key and stops — the Mac is left wiped with no OS. Fast decommissioning wipe; run Erase &amp; restore afterward to make it usable.</p>
+              {/if}
             </div>
 
             <div class="actions">
-              <button class="btn primary" onclick={beginRestore}>{revive ? "Revive" : "Erase & restore"}</button>
+              <button class="btn primary" onclick={beginRestore}>{RESTORE_MODE_LABEL[restoreMode]}</button>
               <button class="btn" onclick={downloadOnly} disabled={!selected.identifier || !!ipswPath}>Download only</button>
               <button class="btn ghost" onclick={rebootTarget} disabled={!!busy}>Reboot</button>
             </div>
@@ -1531,20 +1541,22 @@
   {#if confirming && active}
     <div class="scrim">
       <div class="modal">
-        <div class="eyebrow" style="color:{revive ? 'var(--acc)' : 'var(--danger)'}">{revive ? "Revive" : "Erase & restore"}</div>
-        <h3>{revive ? "Revive this Mac?" : "Erase & restore this Mac?"}</h3>
+        <div class="eyebrow" style="color:{restoreMode === 'revive' ? 'var(--acc)' : 'var(--danger)'}">{RESTORE_MODE_LABEL[restoreMode]}</div>
+        <h3>{restoreMode === "revive" ? "Revive this Mac?" : restoreMode === "obliterate" ? "Obliterate this Mac?" : "Erase & restore this Mac?"}</h3>
         <div class="spec tight">
           <div class="k">Target</div><div class="v">{active.name}</div>
           <div class="k">Firmware</div><div class="v">{firmwareLine()}</div>
         </div>
         <p class="modal-body">
-          {revive
+          {restoreMode === "revive"
             ? "Revive reinstalls firmware and keeps existing data — no erase. The target reboots when done."
-            : "This erases all data on the target and installs a fresh copy of macOS. It cannot be undone."}
+            : restoreMode === "obliterate"
+              ? "This destroys the encryption key and stops — the Mac is wiped but no OS is reinstalled, so it will be left unbootable. Run Erase & restore afterward to make it usable. It cannot be undone."
+              : "This erases all data on the target and installs a fresh copy of macOS. It cannot be undone."}
         </p>
         <div class="modal-actions">
           <button class="btn" onclick={() => { confirming = false; active = null; }}>Cancel</button>
-          <button class="btn {revive ? 'primary' : 'danger'}" onclick={runRestore}>{revive ? "Revive target" : "Erase & restore"}</button>
+          <button class="btn {restoreMode === 'revive' ? 'primary' : 'danger'}" onclick={runRestore}>{restoreMode === "revive" ? "Revive target" : RESTORE_MODE_LABEL[restoreMode]}</button>
         </div>
       </div>
     </div>
@@ -1951,6 +1963,12 @@
     display: flex;
     align-items: center;
     gap: 14px;
+  }
+  .opt-note {
+    margin: 8px 0 0 110px;
+    font-size: 12px;
+    line-height: 1.45;
+    color: var(--danger);
   }
   .ok-label {
     width: 96px;

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -103,6 +103,8 @@ export interface JobView {
   step: string;
   progress: number;
   message: string;
+  /** Erase-restore key-wipe verdict once known, else null. */
+  obliteration?: string | null;
 }
 
 /** A device ever seen by this host, deduped by ECID across modes. */
@@ -128,6 +130,8 @@ export interface HistoryEntry {
   mode: string;
   status: string;
   timestamp_rfc3339: string;
+  /** Erase-restore key-wipe verdict: confirmed | failed | unconfirmed | not_applicable. */
+  obliteration?: string | null;
 }
 
 /** A library progress event, discriminated by `event` (matches the CLI --json). */
@@ -137,6 +141,7 @@ export type ProgressEvent =
   | { event: "download_progress"; received: number; total: number }
   | { event: "verifying" }
   | { event: "restore_step"; step: number; name: string; progress: number }
+  | { event: "obliteration"; status: string; detail: string }
   | { event: "done" }
   | { event: string; [k: string]: unknown };
 

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -105,6 +105,9 @@ export interface JobView {
   message: string;
   /** Erase-restore key-wipe verdict once known, else null. */
   obliteration?: string | null;
+  /** Full checkpoint messages as JSON-array strings (compact JSON / exact XML). */
+  checkpoints_json?: string | null;
+  checkpoints_raw?: string | null;
 }
 
 /** A device ever seen by this host, deduped by ECID across modes. */
@@ -132,6 +135,9 @@ export interface HistoryEntry {
   timestamp_rfc3339: string;
   /** Erase-restore key-wipe verdict: confirmed | failed | unconfirmed | not_applicable. */
   obliteration?: string | null;
+  /** Full checkpoint messages as JSON-array strings (device self-report). */
+  checkpoints_json?: string | null;
+  checkpoints_raw?: string | null;
 }
 
 /** A library progress event, discriminated by `event` (matches the CLI --json). */
@@ -142,6 +148,7 @@ export type ProgressEvent =
   | { event: "verifying" }
   | { event: "restore_step"; step: number; name: string; progress: number }
   | { event: "obliteration"; status: string; detail: string }
+  | { event: "checkpoints"; json: string[]; raw: string[] }
   | { event: "done" }
   | { event: string; [k: string]: unknown };
 

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -188,16 +188,16 @@ export const api = {
   resolveFirmware: (identifier: string, osVersion?: string) =>
     call<Firmware>("resolve_firmware", { identifier, osVersion: osVersion || null }),
   downloadFirmware: (firmware: Firmware) => call<string>("download_firmware", { firmware }),
-  restore: (ipsw: string, serial: string, revive: boolean) =>
-    call<void>("restore", { ipsw, serial, revive }),
+  restore: (ipsw: string, serial: string, mode: string) =>
+    call<void>("restore", { ipsw, serial, mode }),
   cacheInfo: () => call<CacheInfo>("cache_info"),
   clearCache: () => call<void>("clear_cache"),
   historyList: () => call<HistoryEntry[]>("history_list"),
   recordCapture: (entry: HistoryEntry) => call<void>("record_capture", { entry }),
   historyClear: () => call<void>("history_clear"),
   serialQrSvg: (text: string) => call<string>("serial_qr_svg", { text }),
-  enqueueRestore: (ipsw: string, ecid: string, name: string, revive: boolean) =>
-    call<number>("enqueue_restore", { ipsw, ecid, name, revive }),
+  enqueueRestore: (ipsw: string, ecid: string, name: string, mode: string) =>
+    call<number>("enqueue_restore", { ipsw, ecid, name, mode }),
   cancelRestore: (id: number) => call<void>("cancel_restore", { id }),
   restartRestore: (id: number) => call<void>("restart_restore", { id }),
   clearRestoreJob: (id: number) => call<void>("clear_restore_job", { id }),

--- a/apps/landing/src/App.svelte
+++ b/apps/landing/src/App.svelte
@@ -530,7 +530,7 @@
           The whole workflow is one command.
         </h2>
         <p class="mt-4 text-[13.5px] leading-7 text-mut">
-          Run <code class="text-ink2">sudo restorekit erase</code> and bam! It detects the mac,
+          Run <code class="text-ink2">sudo restorekit restore</code> and bam! It detects the mac,
           downloads the right firmware, and restores it to factory settings.
         </p>
         <ul class="mt-6 space-y-3 text-[12.5px] leading-6 text-mut">
@@ -544,15 +544,15 @@
       <div class="self-center">
         {@render cmd(
           "cli",
-          "sudo restorekit erase",
+          "sudo restorekit restore",
           `# wipe and reinstall the latest signed macOS
-$ sudo restorekit erase
+$ sudo restorekit restore
 
 # pick one of several connected Macs
-$ sudo restorekit erase --ecid 0xc60a812345678
+$ sudo restorekit restore --ecid 0xc60a812345678
 
 # no prompts, for scripts
-$ sudo restorekit erase --yes
+$ sudo restorekit restore --yes
 
 # just flip the target into DFU (macOS hosts)
 $ sudo restorekit dfu
@@ -710,9 +710,9 @@ $ restorekit setup-driver`,
           <h3 class="mb-3 text-[11px] tracking-[0.14em] uppercase text-mut">Linux · releases</h3>
           {@render cmd(
             "linux",
-            "sudo restorekit erase",
+            "sudo restorekit restore",
             `# .deb / .AppImage from GitHub releases
-$ sudo restorekit erase`,
+$ sudo restorekit restore`,
           )}
           <p class="mt-3 text-[11.5px] leading-5 text-fnt">
             Skip <code class="text-mut">sudo</code> by installing the bundled

--- a/crates/restorekit-cli/src/commands/restore.rs
+++ b/crates/restorekit-cli/src/commands/restore.rs
@@ -140,6 +140,7 @@ fn restore_device(device: &Device, opts: Opts) -> Result<()> {
 
     match result {
         Ok(_) => {
+            record_restore_history(device, mode, wipe.as_ref(), true);
             // A device-reported wipe failure is fatal even if the restore itself
             // returned success — the key is not proven destroyed.
             if wipe.as_ref().map(|(s, _)| s.as_str()) == Some("failed") {
@@ -152,6 +153,7 @@ fn restore_device(device: &Device, opts: Opts) -> Result<()> {
             Ok(())
         }
         Err(e) => {
+            record_restore_history(device, mode, wipe.as_ref(), false);
             // If the key was destroyed before the restore failed, the data is
             // already unrecoverable; the machine just needs a re-restore for an OS.
             if wipe.as_ref().map(|(s, _)| s.as_str()) == Some("confirmed") {
@@ -165,6 +167,41 @@ fn restore_device(device: &Device, opts: Opts) -> Result<()> {
         }
     }
 }
+
+/// Log the restore to the shared history DB (best-effort — a write failure never
+/// fails the restore). Records a successful restore, or a failed one where the
+/// key was still obliterated, so a wipe that completed before a later failure is
+/// captured for the refurb audit.
+#[cfg(feature = "history")]
+fn record_restore_history(device: &Device, mode: Mode, wipe: Option<&(String, String)>, ok: bool) {
+    use restorekit::history::{self, HistoryEntry};
+
+    let obliteration = wipe.map(|(status, _)| status.clone());
+    let wiped = matches!(obliteration.as_deref(), Some("confirmed") | Some("failed"));
+    if !ok && !wiped {
+        return;
+    }
+    let entry = HistoryEntry {
+        serial_number: device.srnm.clone(),
+        ecid: device.ecid_hex().unwrap_or_default(),
+        model_identifier: device.identifier().map(str::to_string),
+        name: device.display_name(),
+        mode: match mode {
+            Mode::Erase => "erase",
+            Mode::Revive => "revive",
+        }
+        .to_string(),
+        status: if ok { "restored" } else { "restore_failed" }.to_string(),
+        timestamp_rfc3339: history::now_rfc3339(),
+        obliteration,
+    };
+    if let Err(e) = history::record(&entry) {
+        eprintln!("warning: could not record restore history: {e}");
+    }
+}
+
+#[cfg(not(feature = "history"))]
+fn record_restore_history(_: &Device, _: Mode, _: Option<&(String, String)>, _: bool) {}
 
 /// Print the encryption-key obliteration verdict for an erase restore (nothing
 /// for a revive, which does not obliterate). Suppressed in `--json` mode, where

--- a/crates/restorekit-cli/src/commands/restore.rs
+++ b/crates/restorekit-cli/src/commands/restore.rs
@@ -113,6 +113,7 @@ fn restore_device(device: &Device, opts: Opts) -> Result<()> {
     // progress closure and keep a confirmed/failed verdict over a later
     // unconfirmed one across retries.
     let mut wipe: Option<(String, String)> = None;
+    let mut checkpoints: Option<(Vec<String>, Vec<String>)> = None;
     let result = restore::restore(
         &ipsw_path,
         ecid,
@@ -120,11 +121,17 @@ fn restore_device(device: &Device, opts: Opts) -> Result<()> {
         mode,
         opts.verbose,
         &mut |event| {
-            if let Event::Obliteration { status, detail } = &event {
-                let strong = status == "confirmed" || status == "failed";
-                if wipe.is_none() || strong {
-                    wipe = Some((status.clone(), detail.clone()));
+            match &event {
+                Event::Obliteration { status, detail } => {
+                    let strong = status == "confirmed" || status == "failed";
+                    if wipe.is_none() || strong {
+                        wipe = Some((status.clone(), detail.clone()));
+                    }
                 }
+                Event::Checkpoints { json, raw } => {
+                    checkpoints = Some((json.clone(), raw.clone()));
+                }
+                _ => {}
             }
             restore_render(&bar, event, json);
         },
@@ -142,12 +149,12 @@ fn restore_device(device: &Device, opts: Opts) -> Result<()> {
     if mode == Mode::Obliterate {
         return match wipe_status {
             Some("confirmed") => {
-                record_restore_history(device, mode, wipe.as_ref(), true);
+                record_restore_history(device, mode, wipe.as_ref(), checkpoints.as_ref(), true);
                 say(json, completion_message(device, mode));
                 Ok(())
             }
             _ => {
-                record_restore_history(device, mode, wipe.as_ref(), false);
+                record_restore_history(device, mode, wipe.as_ref(), checkpoints.as_ref(), false);
                 Err(result.err().unwrap_or(Error::RestoreFailed {
                     status: -1,
                     log_tail: "obliterate did not confirm the encryption-key wipe".into(),
@@ -158,7 +165,7 @@ fn restore_device(device: &Device, opts: Opts) -> Result<()> {
 
     match result {
         Ok(_) => {
-            record_restore_history(device, mode, wipe.as_ref(), true);
+            record_restore_history(device, mode, wipe.as_ref(), checkpoints.as_ref(), true);
             // A device-reported wipe failure is fatal even if the restore itself
             // returned success — the key is not proven destroyed.
             if wipe.as_ref().map(|(s, _)| s.as_str()) == Some("failed") {
@@ -171,7 +178,7 @@ fn restore_device(device: &Device, opts: Opts) -> Result<()> {
             Ok(())
         }
         Err(e) => {
-            record_restore_history(device, mode, wipe.as_ref(), false);
+            record_restore_history(device, mode, wipe.as_ref(), checkpoints.as_ref(), false);
             // If the key was destroyed before the restore failed, the data is
             // already unrecoverable; the machine just needs a re-restore for an OS.
             if wipe.as_ref().map(|(s, _)| s.as_str()) == Some("confirmed") {
@@ -191,7 +198,13 @@ fn restore_device(device: &Device, opts: Opts) -> Result<()> {
 /// key was still obliterated, so a wipe that completed before a later failure is
 /// captured for the refurb audit.
 #[cfg(feature = "history")]
-fn record_restore_history(device: &Device, mode: Mode, wipe: Option<&(String, String)>, ok: bool) {
+fn record_restore_history(
+    device: &Device,
+    mode: Mode,
+    wipe: Option<&(String, String)>,
+    checkpoints: Option<&(Vec<String>, Vec<String>)>,
+    ok: bool,
+) {
     use restorekit::history::{self, HistoryEntry};
 
     let obliteration = wipe.map(|(status, _)| status.clone());
@@ -199,6 +212,15 @@ fn record_restore_history(device: &Device, mode: Mode, wipe: Option<&(String, St
     if !ok && !wiped {
         return;
     }
+    // Serialize each checkpoint list to a JSON array of strings (handles the
+    // multi-line raw XML records unambiguously). None when nothing was captured.
+    let (checkpoints_json, checkpoints_raw) = match checkpoints {
+        Some((j, r)) => (
+            (!j.is_empty()).then(|| serde_json::to_string(j).unwrap_or_default()),
+            (!r.is_empty()).then(|| serde_json::to_string(r).unwrap_or_default()),
+        ),
+        None => (None, None),
+    };
     let entry = HistoryEntry {
         serial_number: device.srnm.clone(),
         ecid: device.ecid_hex().unwrap_or_default(),
@@ -218,6 +240,8 @@ fn record_restore_history(device: &Device, mode: Mode, wipe: Option<&(String, St
         .to_string(),
         timestamp_rfc3339: history::now_rfc3339(),
         obliteration,
+        checkpoints_json,
+        checkpoints_raw,
     };
     if let Err(e) = history::record(&entry) {
         eprintln!("warning: could not record restore history: {e}");
@@ -225,7 +249,14 @@ fn record_restore_history(device: &Device, mode: Mode, wipe: Option<&(String, St
 }
 
 #[cfg(not(feature = "history"))]
-fn record_restore_history(_: &Device, _: Mode, _: Option<&(String, String)>, _: bool) {}
+fn record_restore_history(
+    _: &Device,
+    _: Mode,
+    _: Option<&(String, String)>,
+    _: Option<&(Vec<String>, Vec<String>)>,
+    _: bool,
+) {
+}
 
 /// Print the encryption-key obliteration verdict for an erase restore (nothing
 /// for a revive, which does not obliterate). Suppressed in `--json` mode, where

--- a/crates/restorekit-cli/src/commands/restore.rs
+++ b/crates/restorekit-cli/src/commands/restore.rs
@@ -112,17 +112,79 @@ fn restore_device(device: &Device, opts: Opts) -> Result<()> {
         );
         b
     };
-    restore::restore(
+    // Capture the wipe verdict from the event stream. It is emitted even when the
+    // restore later fails (the key can be destroyed early), so grab it in the
+    // progress closure and keep a confirmed/failed verdict over a later
+    // unconfirmed one across retries.
+    let mut wipe: Option<(String, String)> = None;
+    let result = restore::restore(
         &ipsw_path,
         ecid,
         Some(&cache),
         mode,
         opts.verbose,
-        &mut |event| restore_render(&bar, event, json),
-    )?;
+        &mut |event| {
+            if let Event::Obliteration { status, detail } = &event {
+                let strong = status == "confirmed" || status == "failed";
+                if wipe.is_none() || strong {
+                    wipe = Some((status.clone(), detail.clone()));
+                }
+            }
+            restore_render(&bar, event, json);
+        },
+    );
     bar.finish_and_clear();
-    say(json, completion_message(device, mode));
-    Ok(())
+
+    // Report the wipe verdict regardless of the restore's overall outcome.
+    report_wipe(json, wipe.as_ref());
+
+    match result {
+        Ok(_) => {
+            // A device-reported wipe failure is fatal even if the restore itself
+            // returned success — the key is not proven destroyed.
+            if wipe.as_ref().map(|(s, _)| s.as_str()) == Some("failed") {
+                return Err(Error::RestoreFailed {
+                    status: -1,
+                    log_tail: "device reported the encryption-key wipe FAILED".into(),
+                });
+            }
+            say(json, completion_message(device, mode));
+            Ok(())
+        }
+        Err(e) => {
+            // If the key was destroyed before the restore failed, the data is
+            // already unrecoverable; the machine just needs a re-restore for an OS.
+            if wipe.as_ref().map(|(s, _)| s.as_str()) == Some("confirmed") {
+                say(
+                    json,
+                    "The encryption key was destroyed before the restore failed, so the \
+                     old data is unrecoverable. Re-run the restore to reinstall the OS.",
+                );
+            }
+            Err(e)
+        }
+    }
+}
+
+/// Print the encryption-key obliteration verdict for an erase restore (nothing
+/// for a revive, which does not obliterate). Suppressed in `--json` mode, where
+/// it already went out as a machine-readable Obliteration event.
+fn report_wipe(json: bool, wipe: Option<&(String, String)>) {
+    let Some((status, detail)) = wipe else { return };
+    match status.as_str() {
+        "confirmed" => say(json, &format!("Encryption key obliterated (verified): {detail}")),
+        "failed" => say(
+            json,
+            &format!("WARNING: the device reported the encryption-key wipe FAILED: {detail}"),
+        ),
+        "unconfirmed" => say(
+            json,
+            "Note: no encryption-key obliteration signal appeared in the device log. The \
+             erase still destroys the key; it just could not be verified. Re-run with \
+             --verbose to inspect the device log.",
+        ),
+        _ => {}
+    }
 }
 
 /// The closing status line, tailored to what the target will actually do next.

--- a/crates/restorekit-cli/src/commands/restore.rs
+++ b/crates/restorekit-cli/src/commands/restore.rs
@@ -205,7 +205,7 @@ fn record_restore_history(device: &Device, mode: Mode, wipe: Option<&(String, St
         model_identifier: device.identifier().map(str::to_string),
         name: device.display_name(),
         mode: match mode {
-            Mode::Erase => "erase",
+            Mode::Erase => "restore",
             Mode::Revive => "revive",
             Mode::Obliterate => "obliterate",
         }
@@ -254,7 +254,7 @@ fn report_wipe(json: bool, wipe: Option<&(String, String)>) {
 fn completion_message(device: &Device, mode: Mode) -> &'static str {
     match (device.is_t2(), mode) {
         (_, Mode::Obliterate) => {
-            "Key obliterated. The Mac is wiped with no OS — run `restorekit erase` to reinstall."
+            "Key obliterated. The Mac is wiped with no OS — run `restorekit restore` to reinstall."
         }
         (true, Mode::Erase) => {
             "bridgeOS restore complete. Reinstall macOS via internet recovery (hold Cmd-R at boot)."
@@ -298,7 +298,7 @@ fn confirm(device: &Device, mode: Mode, yes: bool, json: bool) -> Result<bool> {
             "  This destroys the encryption key and STOPS — no OS is reinstalled. The Mac will"
         );
         println!(
-            "  be left wiped and unbootable; run `restorekit erase` afterward to make it usable."
+            "  be left wiped and unbootable; run `restorekit restore` afterward to make it usable."
         );
     } else if device.is_t2() {
         // A T2 erase restore only reinstalls bridgeOS — unlike Apple Silicon, it

--- a/crates/restorekit-cli/src/commands/restore.rs
+++ b/crates/restorekit-cli/src/commands/restore.rs
@@ -10,7 +10,7 @@ use restorekit::{firmware, restore, Device, Error, Result};
 use super::render;
 
 pub struct Opts {
-    pub revive: bool,
+    pub mode: Mode,
     pub ipsw: Option<PathBuf>,
     pub os_version: Option<String>,
     pub identifier: Option<String>,
@@ -82,11 +82,7 @@ fn restore_device(device: &Device, opts: Opts) -> Result<()> {
         path
     };
 
-    let mode = if opts.revive {
-        Mode::Revive
-    } else {
-        Mode::Erase
-    };
+    let mode = opts.mode;
 
     if !confirm(device, mode, opts.yes, json)? {
         say(json, "Aborted.");
@@ -137,6 +133,28 @@ fn restore_device(device: &Device, opts: Opts) -> Result<()> {
 
     // Report the wipe verdict regardless of the restore's overall outcome.
     report_wipe(json, wipe.as_ref());
+
+    let wipe_status = wipe.as_ref().map(|(s, _)| s.as_str());
+
+    // Obliterate deliberately stops the restore right after the wipe, so a
+    // confirmed wipe is the intended outcome even though idevicerestore may
+    // report the truncated run as an error.
+    if mode == Mode::Obliterate {
+        return match wipe_status {
+            Some("confirmed") => {
+                record_restore_history(device, mode, wipe.as_ref(), true);
+                say(json, completion_message(device, mode));
+                Ok(())
+            }
+            _ => {
+                record_restore_history(device, mode, wipe.as_ref(), false);
+                Err(result.err().unwrap_or(Error::RestoreFailed {
+                    status: -1,
+                    log_tail: "obliterate did not confirm the encryption-key wipe".into(),
+                }))
+            }
+        };
+    }
 
     match result {
         Ok(_) => {
@@ -189,9 +207,15 @@ fn record_restore_history(device: &Device, mode: Mode, wipe: Option<&(String, St
         mode: match mode {
             Mode::Erase => "erase",
             Mode::Revive => "revive",
+            Mode::Obliterate => "obliterate",
         }
         .to_string(),
-        status: if ok { "restored" } else { "restore_failed" }.to_string(),
+        status: match (ok, mode) {
+            (true, Mode::Obliterate) => "obliterated",
+            (true, _) => "restored",
+            (false, _) => "restore_failed",
+        }
+        .to_string(),
         timestamp_rfc3339: history::now_rfc3339(),
         obliteration,
     };
@@ -229,6 +253,9 @@ fn report_wipe(json: bool, wipe: Option<&(String, String)>) {
 /// separately; a T2 revive preserves macOS; Apple Silicon restores fully.
 fn completion_message(device: &Device, mode: Mode) -> &'static str {
     match (device.is_t2(), mode) {
+        (_, Mode::Obliterate) => {
+            "Key obliterated. The Mac is wiped with no OS — run `restorekit erase` to reinstall."
+        }
         (true, Mode::Erase) => {
             "bridgeOS restore complete. Reinstall macOS via internet recovery (hold Cmd-R at boot)."
         }
@@ -263,10 +290,20 @@ fn confirm(device: &Device, mode: Mode, yes: bool, json: bool) -> Result<bool> {
         device.display_name(),
         device.ecid_hex().unwrap_or_default()
     );
-    // A T2 erase restore only reinstalls bridgeOS — unlike Apple Silicon, it does
-    // not put macOS back. Make that explicit so the user isn't left with a Mac
-    // that won't boot. Use `revive` instead to update bridgeOS without erasing.
-    if device.is_t2() {
+    // Obliterate destroys the key and stops — no OS is put back at all. Make the
+    // "you must restore afterward" part explicit so nobody is surprised by a Mac
+    // that won't boot.
+    if mode == Mode::Obliterate {
+        println!(
+            "  This destroys the encryption key and STOPS — no OS is reinstalled. The Mac will"
+        );
+        println!(
+            "  be left wiped and unbootable; run `restorekit erase` afterward to make it usable."
+        );
+    } else if device.is_t2() {
+        // A T2 erase restore only reinstalls bridgeOS — unlike Apple Silicon, it
+        // does not put macOS back. Make that explicit so the user isn't left with
+        // a Mac that won't boot. Use `revive` to update bridgeOS without erasing.
         println!(
             "  This T2 Mac will be wiped and restored to bridgeOS only — macOS is NOT reinstalled."
         );

--- a/crates/restorekit-cli/src/main.rs
+++ b/crates/restorekit-cli/src/main.rs
@@ -49,17 +49,16 @@ enum Command {
         #[arg(long, value_parser = parse_ecid)]
         ecid: Option<u64>,
     },
-    /// Erase and restore the target Mac: triggers DFU entry if needed, then
-    /// downloads firmware and restores. This wipes all data on the target.
-    #[command(alias = "restore")]
-    Erase(RestoreArgs),
+    /// Restore the target Mac: triggers DFU entry if needed, then downloads
+    /// firmware and restores. This wipes all data on the target.
+    Restore(RestoreArgs),
     /// Revive the target Mac: reinstall firmware without erasing user data —
     /// use this to recover a Mac bricked by a failed update.
     Revive(ReviveArgs),
     /// Obliterate the target Mac's encryption key and stop, without reinstalling
     /// the OS: destroys the effaceable media key (cryptographically shredding all
     /// data) then halts, leaving the Mac wiped and OS-less. Fast decommissioning
-    /// wipe; run `erase` afterward to make it usable again.
+    /// wipe; run `restore` afterward to make it usable again.
     Obliterate(RestoreArgs),
     /// Show or manage the firmware cache.
     Cache {
@@ -300,7 +299,7 @@ fn main() {
             os_version,
             ecid,
         } => commands::download::run(identifier, os_version, ecid, cli.cache_dir, cli.json),
-        Command::Erase(args) => commands::restore::run(args.firmware.into_opts(
+        Command::Restore(args) => commands::restore::run(args.firmware.into_opts(
             restorekit::restore::Mode::Erase,
             args.yes,
             cli.cache_dir,

--- a/crates/restorekit-cli/src/main.rs
+++ b/crates/restorekit-cli/src/main.rs
@@ -56,6 +56,11 @@ enum Command {
     /// Revive the target Mac: reinstall firmware without erasing user data —
     /// use this to recover a Mac bricked by a failed update.
     Revive(ReviveArgs),
+    /// Obliterate the target Mac's encryption key and stop, without reinstalling
+    /// the OS: destroys the effaceable media key (cryptographically shredding all
+    /// data) then halts, leaving the Mac wiped and OS-less. Fast decommissioning
+    /// wipe; run `erase` afterward to make it usable again.
+    Obliterate(RestoreArgs),
     /// Show or manage the firmware cache.
     Cache {
         /// Delete all cached firmware.
@@ -240,14 +245,14 @@ fn parse_ecid(s: &str) -> Result<u64, String> {
 impl FirmwareArgs {
     fn into_opts(
         self,
-        revive: bool,
+        mode: restorekit::restore::Mode,
         yes: bool,
         cache_dir: Option<PathBuf>,
         json: bool,
         verbose: bool,
     ) -> commands::restore::Opts {
         commands::restore::Opts {
-            revive,
+            mode,
             ipsw: self.ipsw,
             os_version: self.os_version,
             identifier: self.identifier,
@@ -296,15 +301,22 @@ fn main() {
             ecid,
         } => commands::download::run(identifier, os_version, ecid, cli.cache_dir, cli.json),
         Command::Erase(args) => commands::restore::run(args.firmware.into_opts(
-            false,
+            restorekit::restore::Mode::Erase,
             args.yes,
             cli.cache_dir,
             cli.json,
             cli.verbose,
         )),
         Command::Revive(args) => commands::restore::run(args.firmware.into_opts(
-            true,
+            restorekit::restore::Mode::Revive,
             false,
+            cli.cache_dir,
+            cli.json,
+            cli.verbose,
+        )),
+        Command::Obliterate(args) => commands::restore::run(args.firmware.into_opts(
+            restorekit::restore::Mode::Obliterate,
+            args.yes,
             cli.cache_dir,
             cli.json,
             cli.verbose,

--- a/crates/restorekit-sys/build.rs
+++ b/crates/restorekit-sys/build.rs
@@ -363,9 +363,15 @@ fn patch_idevicerestore_sources(manifest: &Path, vendor_src: &Path, out: &Path) 
     patches.sort();
     for patch in patches {
         println!("cargo:rerun-if-changed={}", patch.display());
+        // Apply with POSIX `patch`, not `git apply`. OUT_DIR lives under this
+        // repo's `target/`, which is git-ignored, and `git apply` run from
+        // inside a work tree silently *skips* patches whose target paths are
+        // ignored (it prints "Skipped patch" but still exits 0), leaving the
+        // sources unpatched. `patch` has no repo awareness, so it applies them
+        // regardless of the surrounding worktree.
         run(
-            Command::new("git")
-                .args(["apply", "--whitespace=nowarn"])
+            Command::new("patch")
+                .args(["-p1", "--no-backup-if-mismatch", "-i"])
                 .arg(&patch)
                 .current_dir(&root),
             &format!("apply {}", patch.file_name().unwrap().to_string_lossy()),

--- a/crates/restorekit-sys/csrc/log_capture.c
+++ b/crates/restorekit-sys/csrc/log_capture.c
@@ -19,7 +19,9 @@ void restorekit_log_capture(int level, const char *msg);
 
 static void restorekit_log_trampoline(enum loglevel level, const char *fmt, va_list ap)
 {
-	char buf[4096];
+	/* Large enough to hold a full CHECKPOINT_RAW line (the exact checkpoint
+	 * plist serialized to XML on one logger call); longer messages truncate. */
+	char buf[65536];
 	vsnprintf(buf, sizeof(buf), fmt, ap);
 	restorekit_log_capture((int)level, buf);
 }

--- a/crates/restorekit-sys/patches/idevicerestore/0003-obliterate-only-stop-after-effaceable-wipe.patch
+++ b/crates/restorekit-sys/patches/idevicerestore/0003-obliterate-only-stop-after-effaceable-wipe.patch
@@ -1,0 +1,36 @@
+diff --git a/src/idevicerestore.h b/src/idevicerestore.h
+index ce8686f..76e7367 100644
+--- a/src/idevicerestore.h
++++ b/src/idevicerestore.h
+@@ -47,6 +47,7 @@ extern "C" {
+ #define FLAG_NO_RESTORE      (1 << 11)
+ #define FLAG_IGNORE_ERRORS   (1 << 12)
+ #define FLAG_KEEP_PERS       (1 << 13)
++#define FLAG_OBLITERATE_ONLY (1 << 14)
+ #define FLAG_IN_PROGRESS     (1 << 30)
+ 
+ #define RESTORE_VARIANT_ERASE_INSTALL      "Erase Install (IPSW)"
+diff --git a/src/restore.c b/src/restore.c
+index eaabef4..b64f59e 100644
+--- a/src/restore.c
++++ b/src/restore.c
+@@ -5709,6 +5709,19 @@ int restore_device(struct idevicerestore_client_t* client, plist_t build_identit
+ 
+ 			if (ckpt_complete) {
+ 				logger(LL_VERBOSE, "Checkpoint completed id: 0x%" PRIX64 " (%s) result=%" PRIi64 "\n", ckpt_id, ckpt_name, ckpt_res);
++				// Obliterate-only: the effaceable-storage format destroys the
++				// media key that encrypts all user data. Once it completes we
++				// have achieved the wipe, so stop cleanly here instead of going
++				// on to write the OS. A non-zero result means the wipe failed.
++				if ((client->flags & FLAG_OBLITERATE_ONLY) && ckpt_name && !strcmp(ckpt_name, "format_effaceable_storage")) {
++					if (ckpt_res == 0) {
++						logger(LL_WARNING, "Obliterate-only: effaceable media key destroyed (result=0); stopping before OS install.\n");
++					} else {
++						logger(LL_ERROR, "Obliterate-only: effaceable wipe failed (result=%" PRIi64 "); aborting.\n", ckpt_res);
++						err = -1;
++					}
++					client->flags |= FLAG_QUIT;
++				}
+ 			} else {
+ 				logger(LL_VERBOSE, "Checkpoint started   id: 0x%" PRIX64 " (%s)\n", ckpt_id, ckpt_name);
+ 			}

--- a/crates/restorekit-sys/patches/idevicerestore/0004-log-full-checkpoint-plists.patch
+++ b/crates/restorekit-sys/patches/idevicerestore/0004-log-full-checkpoint-plists.patch
@@ -1,0 +1,30 @@
+diff --git a/src/restore.c b/src/restore.c
+index eaabef4..0541846 100644
+--- a/src/restore.c
++++ b/src/restore.c
+@@ -5720,6 +5720,25 @@ int restore_device(struct idevicerestore_client_t* client, plist_t build_identit
+ 			if (node) {
+ 				logger(LL_VERBOSE, "Checkpoint FAILURE id: 0x%" PRIX64 " result=%" PRIi64 ": %s\n", ckpt_id, ckpt_res, plist_get_string_ptr(node, NULL));
+ 			}
++			// Emit the full checkpoint message for the host to log verbatim
++			// (restorekit captures these into the restore history): a compact
++			// JSON view, and the exact plist as XML (lossless — all plist types
++			// preserved). These are the device's self-reported status messages,
++			// not Apple-signed attestations.
++			{
++				char* ckpt_json = NULL;
++				uint32_t ckpt_json_len = 0;
++				if (plist_to_json(message, &ckpt_json, &ckpt_json_len, 0) == PLIST_ERR_SUCCESS && ckpt_json) {
++					logger(LL_VERBOSE, "CHECKPOINT_JSON %s\n", ckpt_json);
++				}
++				free(ckpt_json);
++				char* ckpt_xml = NULL;
++				uint32_t ckpt_xml_len = 0;
++				if (plist_to_xml(message, &ckpt_xml, &ckpt_xml_len) == PLIST_ERR_SUCCESS && ckpt_xml) {
++					logger(LL_VERBOSE, "CHECKPOINT_RAW %s\n", ckpt_xml);
++				}
++				free(ckpt_xml);
++			}
+ 		}
+ 
+ 		// baseband update message

--- a/crates/restorekit-sys/src/lib.rs
+++ b/crates/restorekit-sys/src/lib.rs
@@ -49,7 +49,9 @@ extern "C" {
 
 static LOG_LINES: Mutex<Vec<(c_int, String)>> = Mutex::new(Vec::new());
 static LOG_ECHO: AtomicBool = AtomicBool::new(false);
-const LOG_CAPACITY: usize = 512;
+// Large enough that capturing at VERBOSE (see restore.rs) doesn't evict the
+// trailing error/warning lines that error_tail() reports on failure.
+const LOG_CAPACITY: usize = 4096;
 
 /// Optional sink that receives every captured log line as it arrives, for
 /// live-streaming the restore log (see [`set_log_sink`]).

--- a/crates/restorekit-sys/src/lib.rs
+++ b/crates/restorekit-sys/src/lib.rs
@@ -14,6 +14,9 @@ use std::os::raw::{c_char, c_int, c_void};
 // Restore flags from idevicerestore.h.
 pub const FLAG_DEBUG: c_int = 1 << 1;
 pub const FLAG_ERASE: c_int = 1 << 2;
+/// Stop the restore right after the effaceable media-key wipe, before the OS is
+/// written. Combine with `FLAG_ERASE`. Added by patch 0003 (see patches/).
+pub const FLAG_OBLITERATE_ONLY: c_int = 1 << 14;
 
 // idevicerestore log levels (enum loglevel in log.h).
 pub const LL_ERROR: c_int = 0;

--- a/crates/restorekit/migrations/003_obliteration.sql
+++ b/crates/restorekit/migrations/003_obliteration.sql
@@ -1,0 +1,5 @@
+-- Records the encryption-key obliteration verdict for an erase restore:
+-- 'confirmed', 'failed', 'unconfirmed', or 'not_applicable' (see
+-- restore::Obliteration). NULL for rows logged before this column existed and
+-- for non-restore captures.
+ALTER TABLE captures ADD COLUMN obliteration TEXT;

--- a/crates/restorekit/migrations/004_checkpoints.sql
+++ b/crates/restorekit/migrations/004_checkpoints.sql
@@ -1,0 +1,8 @@
+-- The full checkpoint messages the device reported during the restore, stored
+-- as JSON arrays of strings (one element per checkpoint). `checkpoints_json` is
+-- the compact-JSON view of each; `checkpoints_raw` is the exact plist as XML
+-- (lossless). These are the device's self-reported operation log, not an
+-- Apple-signed attestation. NULL for captures and rows logged before this
+-- existed.
+ALTER TABLE captures ADD COLUMN checkpoints_json TEXT;
+ALTER TABLE captures ADD COLUMN checkpoints_raw TEXT;

--- a/crates/restorekit/src/history.rs
+++ b/crates/restorekit/src/history.rs
@@ -31,6 +31,15 @@ pub struct HistoryEntry {
     /// that omit it still deserialize.
     #[serde(default)]
     pub obliteration: Option<String>,
+    /// Full checkpoint messages the device reported during the restore, as a
+    /// JSON array of compact-JSON plists (device self-report, not Apple-signed).
+    /// `None` for captures and older rows.
+    #[serde(default)]
+    pub checkpoints_json: Option<String>,
+    /// The same checkpoints as a JSON array of the exact plists serialized to XML
+    /// (lossless). `None` for captures and older rows.
+    #[serde(default)]
+    pub checkpoints_raw: Option<String>,
 }
 
 /// One device ever seen by this host, deduped by ECID and enriched across the
@@ -57,6 +66,7 @@ fn migrations() -> &'static Migrations<'static> {
             M::up(include_str!("../migrations/001_init.sql")),
             M::up(include_str!("../migrations/002_seen_devices.sql")),
             M::up(include_str!("../migrations/003_obliteration.sql")),
+            M::up(include_str!("../migrations/004_checkpoints.sql")),
         ])
     })
 }
@@ -99,8 +109,9 @@ pub fn record(entry: &HistoryEntry) -> Result<()> {
     let conn = open()?;
     conn.execute(
         "INSERT INTO captures \
-         (serial_number, ecid, model_identifier, name, mode, status, timestamp_rfc3339, obliteration) \
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+         (serial_number, ecid, model_identifier, name, mode, status, timestamp_rfc3339, \
+          obliteration, checkpoints_json, checkpoints_raw) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
         params![
             entry.serial_number,
             entry.ecid,
@@ -110,6 +121,8 @@ pub fn record(entry: &HistoryEntry) -> Result<()> {
             entry.status,
             entry.timestamp_rfc3339,
             entry.obliteration,
+            entry.checkpoints_json,
+            entry.checkpoints_raw,
         ],
     )
     .map_err(db)?;
@@ -122,7 +135,7 @@ pub fn list() -> Result<Vec<HistoryEntry>> {
     let mut stmt = conn
         .prepare(
             "SELECT serial_number, ecid, model_identifier, name, mode, status, timestamp_rfc3339, \
-             obliteration FROM captures ORDER BY id DESC",
+             obliteration, checkpoints_json, checkpoints_raw FROM captures ORDER BY id DESC",
         )
         .map_err(db)?;
     let rows = stmt
@@ -136,6 +149,8 @@ pub fn list() -> Result<Vec<HistoryEntry>> {
                 status: r.get(5)?,
                 timestamp_rfc3339: r.get(6)?,
                 obliteration: r.get(7)?,
+                checkpoints_json: r.get(8)?,
+                checkpoints_raw: r.get(9)?,
             })
         })
         .map_err(db)?;

--- a/crates/restorekit/src/history.rs
+++ b/crates/restorekit/src/history.rs
@@ -82,6 +82,18 @@ fn open() -> Result<Connection> {
     Ok(conn)
 }
 
+/// Current UTC time as an RFC3339 string (e.g. `2026-07-12T20:30:00Z`), for
+/// stamping history entries from Rust callers. Uses SQLite (already a
+/// dependency) so we don't pull in a date library. Empty only if that fails,
+/// which is effectively impossible for an in-memory connection.
+pub fn now_rfc3339() -> String {
+    Connection::open_in_memory()
+        .and_then(|c| {
+            c.query_row("SELECT strftime('%Y-%m-%dT%H:%M:%SZ','now')", [], |r| r.get(0))
+        })
+        .unwrap_or_default()
+}
+
 /// Append a device to the history log.
 pub fn record(entry: &HistoryEntry) -> Result<()> {
     let conn = open()?;
@@ -274,6 +286,14 @@ pub fn export_seen_csv(path: &Path) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn now_rfc3339_is_well_formed() {
+        let ts = super::now_rfc3339();
+        // e.g. 2026-07-12T20:30:00Z
+        assert_eq!(ts.len(), 20, "unexpected timestamp: {ts:?}");
+        assert!(ts.ends_with('Z') && ts.as_bytes()[10] == b'T', "bad shape: {ts:?}");
+    }
+
     #[test]
     fn migrations_are_valid() {
         // Embedded migrations must parse and apply to an in-memory DB.

--- a/crates/restorekit/src/history.rs
+++ b/crates/restorekit/src/history.rs
@@ -25,6 +25,12 @@ pub struct HistoryEntry {
     pub mode: String,
     pub status: String,
     pub timestamp_rfc3339: String,
+    /// Encryption-key obliteration verdict for an erase restore (`confirmed`,
+    /// `failed`, `unconfirmed`, `not_applicable`); `None` for captures and rows
+    /// logged before this was tracked. Defaulted so older records and callers
+    /// that omit it still deserialize.
+    #[serde(default)]
+    pub obliteration: Option<String>,
 }
 
 /// One device ever seen by this host, deduped by ECID and enriched across the
@@ -50,6 +56,7 @@ fn migrations() -> &'static Migrations<'static> {
         Migrations::new(vec![
             M::up(include_str!("../migrations/001_init.sql")),
             M::up(include_str!("../migrations/002_seen_devices.sql")),
+            M::up(include_str!("../migrations/003_obliteration.sql")),
         ])
     })
 }
@@ -80,8 +87,8 @@ pub fn record(entry: &HistoryEntry) -> Result<()> {
     let conn = open()?;
     conn.execute(
         "INSERT INTO captures \
-         (serial_number, ecid, model_identifier, name, mode, status, timestamp_rfc3339) \
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+         (serial_number, ecid, model_identifier, name, mode, status, timestamp_rfc3339, obliteration) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
         params![
             entry.serial_number,
             entry.ecid,
@@ -90,6 +97,7 @@ pub fn record(entry: &HistoryEntry) -> Result<()> {
             entry.mode,
             entry.status,
             entry.timestamp_rfc3339,
+            entry.obliteration,
         ],
     )
     .map_err(db)?;
@@ -101,8 +109,8 @@ pub fn list() -> Result<Vec<HistoryEntry>> {
     let conn = open()?;
     let mut stmt = conn
         .prepare(
-            "SELECT serial_number, ecid, model_identifier, name, mode, status, timestamp_rfc3339 \
-             FROM captures ORDER BY id DESC",
+            "SELECT serial_number, ecid, model_identifier, name, mode, status, timestamp_rfc3339, \
+             obliteration FROM captures ORDER BY id DESC",
         )
         .map_err(db)?;
     let rows = stmt
@@ -115,6 +123,7 @@ pub fn list() -> Result<Vec<HistoryEntry>> {
                 mode: r.get(4)?,
                 status: r.get(5)?,
                 timestamp_rfc3339: r.get(6)?,
+                obliteration: r.get(7)?,
             })
         })
         .map_err(db)?;
@@ -139,7 +148,7 @@ fn csv_field(s: &str) -> String {
 /// Write the whole history to `path` as a spreadsheet-openable CSV.
 pub fn export_csv(path: &Path) -> Result<()> {
     let entries = list()?;
-    let mut out = String::from("Timestamp,Serial,ECID,Model,Name,Mode,Status\n");
+    let mut out = String::from("Timestamp,Serial,ECID,Model,Name,Mode,Status,Obliteration\n");
     for e in &entries {
         let cols = [
             e.timestamp_rfc3339.as_str(),
@@ -149,6 +158,7 @@ pub fn export_csv(path: &Path) -> Result<()> {
             e.name.as_str(),
             e.mode.as_str(),
             e.status.as_str(),
+            e.obliteration.as_deref().unwrap_or(""),
         ];
         out.push_str(
             &cols
@@ -270,14 +280,14 @@ mod tests {
         let mut conn = rusqlite::Connection::open_in_memory().unwrap();
         super::migrations().to_latest(&mut conn).unwrap();
         conn.execute(
-            "INSERT INTO captures (ecid, name, mode, status, timestamp_rfc3339) \
-             VALUES ('0x1', 'Mac', 'recovery', 'captured', '2026-01-01T00:00:00Z')",
+            "INSERT INTO captures (ecid, name, mode, status, timestamp_rfc3339, obliteration) \
+             VALUES ('0x1', 'Mac', 'restore', 'restored', '2026-01-01T00:00:00Z', 'confirmed')",
             [],
         )
         .unwrap();
-        let n: i64 = conn
-            .query_row("SELECT count(*) FROM captures", [], |r| r.get(0))
+        let obl: Option<String> = conn
+            .query_row("SELECT obliteration FROM captures", [], |r| r.get(0))
             .unwrap();
-        assert_eq!(n, 1);
+        assert_eq!(obl.as_deref(), Some("confirmed"));
     }
 }

--- a/crates/restorekit/src/lib.rs
+++ b/crates/restorekit/src/lib.rs
@@ -83,7 +83,7 @@ pub use dongle::{Connection, Dongle, DongleHandle, DongleStatus, DongleTarget, P
 pub use error::{Error, Result};
 pub use firmware::Firmware;
 pub use progress::Event;
-pub use restore::Mode;
+pub use restore::{Mode, Obliteration};
 
 /// A shared embedded usbmuxd the parent process holds while it spawns per-device
 /// restore workers. Child `restore` processes detect it (via the

--- a/crates/restorekit/src/progress.rs
+++ b/crates/restorekit/src/progress.rs
@@ -49,6 +49,13 @@ pub enum Event {
         level: i32,
         line: String,
     },
+    /// Result of the encryption-key obliteration check after an erase restore.
+    /// `status` is one of `confirmed`, `failed`, `unconfirmed`, `not_applicable`;
+    /// `detail` carries the device log line that classified it, when any.
+    Obliteration {
+        status: String,
+        detail: String,
+    },
     /// A restore attempt failed on a transient transport error (e.g. a dropped
     /// USB write mid-transfer) and is being retried from the top.
     RestoreRetrying {

--- a/crates/restorekit/src/progress.rs
+++ b/crates/restorekit/src/progress.rs
@@ -56,6 +56,15 @@ pub enum Event {
         status: String,
         detail: String,
     },
+    /// The full checkpoint messages the device reported during the restore,
+    /// captured for the history audit trail. `json` holds one compact-JSON plist
+    /// per entry; `raw` holds the exact plist as XML (lossless). Emitted once
+    /// near the end. These are the device's self-reported status messages, not
+    /// Apple-signed attestations.
+    Checkpoints {
+        json: Vec<String>,
+        raw: Vec<String>,
+    },
     /// A restore attempt failed on a transient transport error (e.g. a dropped
     /// USB write mid-transfer) and is being retried from the top.
     RestoreRetrying {

--- a/crates/restorekit/src/restore.rs
+++ b/crates/restorekit/src/restore.rs
@@ -1,6 +1,6 @@
 use std::ffi::{c_void, CString};
 use std::path::Path;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use restorekit_sys as sys;
 
@@ -14,6 +14,112 @@ pub enum Mode {
     Erase,
     /// Update-style restore that preserves user data ("revive").
     Revive,
+}
+
+/// Outcome of the encryption-key obliteration check for an erase restore.
+///
+/// On Apple Silicon and T2 the media key that encrypts all user data lives in
+/// effaceable storage managed by the SEP; an erase restore reformats that
+/// region, destroying the key and cryptographically shredding the old data. The
+/// key itself is never readable, so the strongest signal available is the
+/// device's own report in the restore log — we scan for it and classify here.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Obliteration {
+    /// Revive restore — no erase requested, so nothing is obliterated.
+    NotApplicable,
+    /// The device reported the effaceable storage was formatted (media key
+    /// destroyed). `evidence` is the log line that confirmed it.
+    Confirmed { evidence: String },
+    /// The device reported the effaceable format failed. `evidence` is the log
+    /// line. The old key may still be present — treat the wipe as unproven.
+    Failed { evidence: String },
+    /// The erase restore itself succeeded but no obliteration signal appeared in
+    /// the device log. The signal may simply not cross to the host on this
+    /// model/OS; re-run with `--verbose` to inspect the full device log.
+    Unconfirmed,
+}
+
+impl Obliteration {
+    /// Machine-readable status tag (matches [`Event::Obliteration`]).
+    pub fn status(&self) -> &'static str {
+        match self {
+            Obliteration::NotApplicable => "not_applicable",
+            Obliteration::Confirmed { .. } => "confirmed",
+            Obliteration::Failed { .. } => "failed",
+            Obliteration::Unconfirmed => "unconfirmed",
+        }
+    }
+
+    /// The device log line that produced this verdict, if any.
+    pub fn evidence(&self) -> Option<&str> {
+        match self {
+            Obliteration::Confirmed { evidence } | Obliteration::Failed { evidence } => {
+                Some(evidence)
+            }
+            _ => None,
+        }
+    }
+}
+
+/// Accumulates obliteration signals seen in the restore log stream. Failure
+/// dominates success; the first line of each kind is kept as evidence.
+#[derive(Default)]
+struct ObliterationScan {
+    confirmed: Option<String>,
+    failed: Option<String>,
+}
+
+impl ObliterationScan {
+    fn observe(&mut self, line: &str) {
+        let l = line.to_ascii_lowercase();
+        // Primary signal, verified on a real M1 (MacBookPro17,1) erase restore:
+        // the device forwards its effaceable-media-key wipe to the host as a
+        // restore checkpoint, e.g.
+        //   Checkpoint completed id: 0x61F (format_effaceable_storage) result=0
+        // `result=0` is success; any non-zero code is a failed wipe. The
+        // "started" line has no `result=` and is ignored. This crosses the USB
+        // link; `restored_update`'s on-device syslog string does not.
+        if l.contains("format_effaceable_storage") {
+            if let Some(code) = l
+                .split("result=")
+                .nth(1)
+                .and_then(|s| s.split_whitespace().next())
+            {
+                if code == "0" {
+                    self.confirmed.get_or_insert_with(|| line.to_string());
+                } else {
+                    self.failed.get_or_insert_with(|| line.to_string());
+                }
+            }
+            return;
+        }
+        // Fallback: `restored_update`'s textual report, in case some model/OS
+        // surfaces it to the host instead of (or before) the checkpoint.
+        const FAIL: &[&str] = &[
+            "failed to format effaceable storage",
+            "error formatting effaceable storage",
+        ];
+        const OK: &[&str] = &["effaceable storage formatted successfully"];
+        if self.failed.is_none() && FAIL.iter().any(|m| l.contains(m)) {
+            self.failed = Some(line.to_string());
+        } else if self.confirmed.is_none() && OK.iter().any(|m| l.contains(m)) {
+            self.confirmed = Some(line.to_string());
+        }
+    }
+
+    fn result(&self) -> Obliteration {
+        if let Some(e) = &self.failed {
+            Obliteration::Failed {
+                evidence: e.clone(),
+            }
+        } else if let Some(e) = &self.confirmed {
+            Obliteration::Confirmed {
+                evidence: e.clone(),
+            }
+        } else {
+            Obliteration::Unconfirmed
+        }
+    }
 }
 
 /// Human name for an idevicerestore progress step.
@@ -97,7 +203,7 @@ pub fn restore(
     mode: Mode,
     verbose: bool,
     progress: ProgressFn,
-) -> Result<()> {
+) -> Result<Obliteration> {
     let _guard = RESTORE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 
     // On Linux and Windows, start the embedded usbmuxd server so idevicerestore
@@ -120,9 +226,11 @@ pub fn restore(
     let mut attempt = 1;
     loop {
         match restore_attempt(ipsw, ecid, cache_dir, mode, verbose, progress) {
-            Ok(()) => {
+            Ok(obliteration) => {
+                // The worker already emitted the Obliteration event (it fires on
+                // failure too); just close out the successful run.
                 progress(Event::Done);
-                return Ok(());
+                return Ok(obliteration);
             }
             Err(e) if attempt < RESTORE_ATTEMPTS && is_transient_failure(&e) => {
                 progress(Event::RestoreRetrying {
@@ -146,7 +254,7 @@ fn restore_attempt(
     mode: Mode,
     verbose: bool,
     progress: ProgressFn,
-) -> Result<()> {
+) -> Result<Obliteration> {
     // Route idevicerestore's logging through our capture sink (rather than its
     // default stdout dump) so it doesn't stomp on the progress UI and so we can
     // surface the real error text on failure. `verbose` also echoes to stderr.
@@ -176,7 +284,7 @@ fn restore_attempt(
     let worker = std::thread::Builder::new()
         .name("restore".into())
         .stack_size(RESTORE_STACK)
-        .spawn(move || -> Result<()> {
+        .spawn(move || -> Result<Obliteration> {
             let ipsw_c = CString::new(ipsw.as_os_str().to_string_lossy().as_bytes())
                 .map_err(|_| Error::Download("ipsw path contains a NUL byte".into()))?;
             let cache_c = cache_dir
@@ -211,11 +319,18 @@ fn restore_attempt(
                         &tx as *const std::sync::mpsc::Sender<Event> as *mut c_void,
                     );
 
-                    // Stream each log line as an event for a live log window. The
+                    // Stream each log line as an event for a live log window, and
+                    // scan it for the device's effaceable-obliteration signals. The
                     // sink is cleared before the worker's own sender drops, so the
                     // caller's `rx` loop still terminates.
                     let tx_log = tx.clone();
+                    let scan = Arc::new(Mutex::new(ObliterationScan::default()));
+                    let scan_sink = Arc::clone(&scan);
                     sys::set_log_sink(Some(Box::new(move |level, line| {
+                        scan_sink
+                            .lock()
+                            .unwrap_or_else(|e| e.into_inner())
+                            .observe(line);
                         let _ = tx_log.send(Event::LogLine {
                             level,
                             line: line.to_string(),
@@ -223,8 +338,23 @@ fn restore_attempt(
                     })));
                     let rc = sys::idevicerestore_start(client);
                     sys::set_log_sink(None);
+                    let obliteration = match mode {
+                        Mode::Revive => Obliteration::NotApplicable,
+                        Mode::Erase => scan.lock().unwrap_or_else(|e| e.into_inner()).result(),
+                    };
+                    // Report the wipe verdict for BOTH outcomes: an erase can
+                    // destroy the media key early and still fail later (e.g. the
+                    // OS-image upload drops), and a refurb audit must capture
+                    // that the key is gone regardless. Skip the noise event for a
+                    // revive, which never obliterates.
+                    if !matches!(obliteration, Obliteration::NotApplicable) {
+                        let _ = tx.send(Event::Obliteration {
+                            status: obliteration.status().to_string(),
+                            detail: obliteration.evidence().unwrap_or_default().to_string(),
+                        });
+                    }
                     if rc == 0 {
-                        Ok(())
+                        Ok(obliteration)
                     } else {
                         let tail = sys::error_tail(20);
                         let log_tail = if tail.is_empty() {
@@ -273,6 +403,36 @@ mod tests {
             "uploading filesystem"
         );
         assert_eq!(step_name(999), "restoring");
+    }
+
+    #[test]
+    fn obliteration_scan_classifies_signals() {
+        // The real host-visible signal (verified on an M1 erase restore): a
+        // restore checkpoint with a result code. The "started" line is not a
+        // verdict; only the "completed … result=" line is.
+        let mut s = ObliterationScan::default();
+        s.observe("Checkpoint started   id: 0x61F (format_effaceable_storage)");
+        assert_eq!(s.result(), Obliteration::Unconfirmed);
+        s.observe("Checkpoint completed id: 0x61F (format_effaceable_storage) result=0");
+        assert!(matches!(s.result(), Obliteration::Confirmed { .. }));
+
+        // A non-zero checkpoint result is a failed wipe.
+        let mut s = ObliterationScan::default();
+        s.observe("Checkpoint completed id: 0x61F (format_effaceable_storage) result=5");
+        assert!(matches!(s.result(), Obliteration::Failed { .. }));
+
+        // Unrelated lines and the ambiguous "nothing to do" leave it unconfirmed.
+        let mut s = ObliterationScan::default();
+        s.observe("preparing NAND");
+        s.observe("restored_update: effaceable storage is formatted, nothing to do");
+        assert_eq!(s.result(), Obliteration::Unconfirmed);
+
+        // Textual fallback still works; failure dominates a prior success.
+        let mut s = ObliterationScan::default();
+        s.observe("effaceable storage formatted successfully");
+        assert!(matches!(s.result(), Obliteration::Confirmed { .. }));
+        s.observe("failed to format effaceable storage");
+        assert!(matches!(s.result(), Obliteration::Failed { .. }));
     }
 
     #[test]

--- a/crates/restorekit/src/restore.rs
+++ b/crates/restorekit/src/restore.rs
@@ -190,10 +190,21 @@ fn is_transient_failure(err: &Error) -> bool {
         "Unable to place device into recovery mode from DFU mode",
         "Unable to send iBoot stage 1 components",
     ];
-    match err {
-        Error::RestoreFailed { log_tail, .. } => MARKERS.iter().any(|m| log_tail.contains(m)),
-        _ => false,
-    }
+    // The ASR filesystem push dropping mid-transfer (flaky USB) is transient, but
+    // its signature gets buried: the device emits dozens of trailing errors (the
+    // per-chunk send retries, then "Unable to discover device mode") that push
+    // the real marker out of the short display tail. So scan a much larger slice
+    // of the just-failed attempt's captured log for the ASR-drop signature.
+    // These are specific to the transport push and never appear in a genuine
+    // restore-operation failure, so they won't cause those to retry.
+    const TRANSPORT_MARKERS: &[&str] = &["Unable to send data to ASR", "Unable to send filesystem"];
+    let Error::RestoreFailed { log_tail, .. } = err else {
+        return false;
+    };
+    MARKERS.iter().any(|m| log_tail.contains(m))
+        || TRANSPORT_MARKERS
+            .iter()
+            .any(|m| sys::error_tail(500).contains(m))
 }
 
 /// Run a restore against the DFU device with the given ECID, streaming progress.

--- a/crates/restorekit/src/restore.rs
+++ b/crates/restorekit/src/restore.rs
@@ -14,6 +14,11 @@ pub enum Mode {
     Erase,
     /// Update-style restore that preserves user data ("revive").
     Revive,
+    /// Destroy the encryption (media) key and stop — the effaceable wipe runs
+    /// but the OS is not reinstalled, leaving the Mac wiped and OS-less. Fast
+    /// key destruction for decommissioning; requires a later restore to be
+    /// usable again (`FLAG_ERASE | FLAG_OBLITERATE_ONLY`).
+    Obliterate,
 }
 
 /// Outcome of the encryption-key obliteration check for an erase restore.
@@ -307,6 +312,7 @@ fn restore_attempt(
                     let flags = match mode {
                         Mode::Erase => sys::FLAG_ERASE,
                         Mode::Revive => 0,
+                        Mode::Obliterate => sys::FLAG_ERASE | sys::FLAG_OBLITERATE_ONLY,
                     };
                     sys::idevicerestore_set_flags(client, flags);
                     sys::idevicerestore_set_ipsw(client, ipsw_c.as_ptr());
@@ -340,7 +346,9 @@ fn restore_attempt(
                     sys::set_log_sink(None);
                     let obliteration = match mode {
                         Mode::Revive => Obliteration::NotApplicable,
-                        Mode::Erase => scan.lock().unwrap_or_else(|e| e.into_inner()).result(),
+                        Mode::Erase | Mode::Obliterate => {
+                            scan.lock().unwrap_or_else(|e| e.into_inner()).result()
+                        }
                     };
                     // Report the wipe verdict for BOTH outcomes: an erase can
                     // destroy the media key early and still fail later (e.g. the

--- a/crates/restorekit/src/restore.rs
+++ b/crates/restorekit/src/restore.rs
@@ -263,11 +263,18 @@ fn restore_attempt(
     // Route idevicerestore's logging through our capture sink (rather than its
     // default stdout dump) so it doesn't stomp on the progress UI and so we can
     // surface the real error text on failure. `verbose` also echoes to stderr.
+    //
+    // Capture at VERBOSE even when the user didn't ask for verbose output: the
+    // effaceable-wipe confirmation we scan for (the `format_effaceable_storage`
+    // checkpoint) is logged by idevicerestore at LL_VERBOSE, so a WARNING-level
+    // threshold would drop it and every obliteration would read as unconfirmed
+    // (fatal for `obliterate`). Echo to stderr stays gated on `verbose`, so
+    // non-verbose runs still look quiet — they just capture more internally.
     sys::install_log_capture(verbose);
     sys::set_log_level(if verbose {
         sys::LL_DEBUG
     } else {
-        sys::LL_WARNING
+        sys::LL_VERBOSE
     });
 
     // Initialize idevicerestore's global progress mutex up front — some of its

--- a/crates/restorekit/src/restore.rs
+++ b/crates/restorekit/src/restore.rs
@@ -339,11 +339,31 @@ fn restore_attempt(
                     let tx_log = tx.clone();
                     let scan = Arc::new(Mutex::new(ObliterationScan::default()));
                     let scan_sink = Arc::clone(&scan);
+                    // Full checkpoint messages the device reports, captured for the
+                    // history audit trail (emitted by idevicerestore patch 0004):
+                    // `CHECKPOINT_JSON <compact json>` and `CHECKPOINT_RAW <xml>`
+                    // (the exact, lossless plist). Kept out of the evictable sys
+                    // capture buffer so none are lost to log volume.
+                    let ckpt_json = Arc::new(Mutex::new(Vec::<String>::new()));
+                    let ckpt_raw = Arc::new(Mutex::new(Vec::<String>::new()));
+                    let ckpt_json_sink = Arc::clone(&ckpt_json);
+                    let ckpt_raw_sink = Arc::clone(&ckpt_raw);
                     sys::set_log_sink(Some(Box::new(move |level, line| {
                         scan_sink
                             .lock()
                             .unwrap_or_else(|e| e.into_inner())
                             .observe(line);
+                        if let Some(pos) = line.find("CHECKPOINT_JSON ") {
+                            ckpt_json_sink
+                                .lock()
+                                .unwrap_or_else(|e| e.into_inner())
+                                .push(line[pos + "CHECKPOINT_JSON ".len()..].to_string());
+                        } else if let Some(pos) = line.find("CHECKPOINT_RAW ") {
+                            ckpt_raw_sink
+                                .lock()
+                                .unwrap_or_else(|e| e.into_inner())
+                                .push(line[pos + "CHECKPOINT_RAW ".len()..].to_string());
+                        }
                         let _ = tx_log.send(Event::LogLine {
                             level,
                             line: line.to_string(),
@@ -367,6 +387,16 @@ fn restore_attempt(
                             status: obliteration.status().to_string(),
                             detail: obliteration.evidence().unwrap_or_default().to_string(),
                         });
+                    }
+                    // Hand off the full checkpoint messages (device self-reported;
+                    // not Apple-signed) for the history record, on success or
+                    // failure alike.
+                    let json =
+                        std::mem::take(&mut *ckpt_json.lock().unwrap_or_else(|e| e.into_inner()));
+                    let raw =
+                        std::mem::take(&mut *ckpt_raw.lock().unwrap_or_else(|e| e.into_inner()));
+                    if !json.is_empty() || !raw.is_empty() {
+                        let _ = tx.send(Event::Checkpoints { json, raw });
                     }
                     if rc == 0 {
                         Ok(obliteration)

--- a/crates/restorekit/tests/history_roundtrip.rs
+++ b/crates/restorekit/tests/history_roundtrip.rs
@@ -16,9 +16,10 @@ fn record_list_export_clear_roundtrip() {
         ecid: "0x77aa22bb44cc".into(),
         model_identifier: Some("Mac14,2".into()),
         name: "MacBook Air (M2, 2022)".into(), // contains a comma → must be CSV-quoted
-        mode: "recovery".into(),
-        status: "captured".into(),
+        mode: "restore".into(),
+        status: "restored".into(),
         timestamp_rfc3339: "2026-01-01T00:00:00Z".into(),
+        obliteration: Some("confirmed".into()),
     };
     history::record(&entry).unwrap();
 
@@ -26,12 +27,14 @@ fn record_list_export_clear_roundtrip() {
     assert_eq!(all.len(), 1);
     assert_eq!(all[0].serial_number.as_deref(), Some("C02XX1234567"));
     assert_eq!(all[0].name, "MacBook Air (M2, 2022)");
+    assert_eq!(all[0].obliteration.as_deref(), Some("confirmed"));
 
     let csv = dir.join("out.csv");
     history::export_csv(&csv).unwrap();
     let text = std::fs::read_to_string(&csv).unwrap();
-    assert!(text.starts_with("Timestamp,Serial,ECID,Model,Name,Mode,Status"));
+    assert!(text.starts_with("Timestamp,Serial,ECID,Model,Name,Mode,Status,Obliteration"));
     assert!(text.contains("\"MacBook Air (M2, 2022)\""));
+    assert!(text.trim_end().ends_with("confirmed"));
 
     history::clear().unwrap();
     assert_eq!(history::list().unwrap().len(), 0);

--- a/crates/restorekit/tests/history_roundtrip.rs
+++ b/crates/restorekit/tests/history_roundtrip.rs
@@ -20,6 +20,8 @@ fn record_list_export_clear_roundtrip() {
         status: "restored".into(),
         timestamp_rfc3339: "2026-01-01T00:00:00Z".into(),
         obliteration: Some("confirmed".into()),
+        checkpoints_json: Some(r#"["{\"CHECKPOINT_NAME\":\"format_effaceable_storage\"}"]"#.into()),
+        checkpoints_raw: Some(r#"["<plist>…</plist>"]"#.into()),
     };
     history::record(&entry).unwrap();
 

--- a/docs/obliterate.md
+++ b/docs/obliterate.md
@@ -1,0 +1,109 @@
+# How `obliterate` works
+
+`restorekit obliterate` destroys a Mac's encryption key and stops — it wipes the
+machine without spending the time (or bandwidth) to reinstall the OS. On the
+hardware we tested it completes in about **30 seconds**, versus 15–30 minutes for
+a full `restore`.
+
+This document explains the security model it relies on and exactly what the
+command does.
+
+## The security model: erase by destroying the key
+
+On Apple Silicon and T2 Macs, **all user data on the internal storage is always
+encrypted**. Each volume is encrypted with a volume key, and those keys are
+ultimately wrapped by a hardware **media key** held in a small region of storage
+called **effaceable storage**, managed by the Secure Enclave.
+
+Because every byte is already encrypted under that key, you don't have to
+overwrite the data to erase it — you destroy the media key. Once the media key is
+gone, the wrapped volume keys can never be recovered, so the ciphertext on the
+drive is permanently unreadable. Apple calls this cryptographic erasure, and it's
+the same primitive behind "Erase All Content and Settings."
+
+- Apple Platform Security — Data Protection overview:
+  <https://support.apple.com/guide/security/data-protection-sece8608431d/web>
+- Apple Platform Security — Secure Enclave / effaceable storage:
+  <https://support.apple.com/guide/security/secure-enclave-sec59b0b31ff/web>
+
+`obliterate` performs exactly this key destruction and nothing more.
+
+## What the command does
+
+A normal erase restore boots a restore ramdisk over DFU, wipes the effaceable
+storage early on, and *then* spends most of its time writing the OS image back.
+`obliterate` runs that same flow but **stops the moment the key is destroyed**,
+before the OS write:
+
+1. Trigger DFU entry on the target (via the dongle, or the host on Apple Silicon
+   macOS).
+2. Personalize and boot the restore ramdisk — identical to an erase restore up to
+   this point.
+3. The device runs its restore sequence and reports a **checkpoint** to the host
+   for each step. When it completes the effaceable-storage format —
+
+   ```
+   Checkpoint completed id: 0x61F (format_effaceable_storage) result=0
+   ```
+
+   — the media key has been destroyed (`result=0` means success).
+4. restorekit stops the restore cleanly at that checkpoint instead of continuing
+   to the OS upload. The device is left wiped and OS-less.
+
+Everything before step 3 is byte-for-byte a normal erase restore; the only
+difference is that `obliterate` bails out at the wipe checkpoint.
+
+## How the stop is implemented
+
+restorekit vendors and patches [idevicerestore](https://github.com/libimobiledevice/idevicerestore).
+Patch `0003` (see `crates/restorekit-sys/patches/idevicerestore/`) adds a
+`FLAG_OBLITERATE_ONLY` restore flag. In the restore message loop, when that flag
+is set and the `format_effaceable_storage` checkpoint completes, it sets the
+existing `FLAG_QUIT` — the same mechanism a normal successful restore uses to end
+its loop — so the restore returns cleanly right after the wipe. A non-zero
+checkpoint result is treated as a failed wipe and aborts with an error.
+
+`Mode::Obliterate` sets `FLAG_ERASE | FLAG_OBLITERATE_ONLY`. It's a normal erase
+as far as the device is concerned; the host just refuses to go any further once
+the key is gone.
+
+## Verification
+
+The wipe verdict is derived by scanning the restore log for that
+`format_effaceable_storage` checkpoint and its result code:
+
+- `result=0` → `confirmed` (key destroyed)
+- non-zero → `failed`
+- checkpoint never seen → `unconfirmed`
+
+For `obliterate`, a `confirmed` verdict is the successful outcome. The verdict is
+surfaced in the CLI output and the `obliteration` progress event, and recorded to
+the history log. Because the key is destroyed inside the Secure Enclave, this
+checkpoint attestation is the strongest confirmation available — the key value
+itself is never readable, by design.
+
+## End state and caveats
+
+- After `obliterate` the Mac is **wiped and has no OS**. It sits in restore mode
+  and falls back to DFU. Run `restorekit restore` to reinstall macOS and make it
+  usable again.
+- Obliteration needs Apple's signing server (TSS) online at wipe time to boot the
+  personalized ramdisk — it is not an offline operation.
+- The target's data is unrecoverable the instant the checkpoint reports
+  `result=0`, whether or not the tool later reports success.
+
+## Usage
+
+```sh
+# Destroy the key and stop (leaves the Mac wiped, no OS)
+sudo restorekit obliterate --yes
+
+# Time it
+sudo -v && time sudo restorekit obliterate --yes
+
+# Reinstall an OS afterward
+sudo restorekit restore --yes
+```
+
+In the desktop app, pick **Obliterate** in the restore Mode selector; the confirm
+dialog spells out that no OS is reinstalled.

--- a/docs/obliterate.md
+++ b/docs/obliterate.md
@@ -90,10 +90,10 @@ signature. What you trust is one level down: the ramdisk emitting them is
 Apple-signed and personalized to the device by the boot chain, so it's genuine
 Apple restore firmware reporting `result=0` — but that is trust rooted in the
 boot chain, not a signature you can verify on the message. The protocol does have
-a `RestoreAttestation` step, but idevicerestore explicitly declines it
-(`RestoreShouldAttest: false`), so no signed attestation is collected. Treat the
-checkpoints as an authenticated-by-boot-chain self-report, not a signed
-certificate.
+a `RestoreAttestation` step, but it's an Apple-account-gated dead end for a
+third-party tool (and not a proof of erasure anyway) — see
+[restore-attestation.md](restore-attestation.md). Treat the checkpoints as an
+authenticated-by-boot-chain self-report, not a signed certificate.
 
 ### Full checkpoint audit log
 

--- a/docs/obliterate.md
+++ b/docs/obliterate.md
@@ -82,6 +82,28 @@ the history log. Because the key is destroyed inside the Secure Enclave, this
 checkpoint attestation is the strongest confirmation available — the key value
 itself is never readable, by design.
 
+### Are the checkpoints signed?
+
+No. Each checkpoint is a plist the restore daemon sends back to the host over the
+USB restore channel (received via `restored_receive`); there is no per-message
+signature. What you trust is one level down: the ramdisk emitting them is
+Apple-signed and personalized to the device by the boot chain, so it's genuine
+Apple restore firmware reporting `result=0` — but that is trust rooted in the
+boot chain, not a signature you can verify on the message. The protocol does have
+a `RestoreAttestation` step, but idevicerestore explicitly declines it
+(`RestoreShouldAttest: false`), so no signed attestation is collected. Treat the
+checkpoints as an authenticated-by-boot-chain self-report, not a signed
+certificate.
+
+### Full checkpoint audit log
+
+Every checkpoint message the device reports is captured to the history record
+(patch 0004 emits each as `CHECKPOINT_JSON <compact json>` and `CHECKPOINT_RAW
+<exact plist XML>`). The history DB stores them in two columns —
+`checkpoints_json` (readable/queryable) and `checkpoints_raw` (the exact,
+lossless plists) — each a JSON array with one entry per checkpoint. This gives a
+complete operation log of what the device reported during the wipe.
+
 ## End state and caveats
 
 - After `obliterate` the Mac is **wiped and has no OS**. It sits in restore mode

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -65,6 +65,8 @@ and linked in. No subprocess, no `brew install idevicerestore`.
 - [x] Release build (`cargo build --release`) links; 8.2 MB self-contained binary, no third-party dylibs
 - [x] Hardware: `sudo restorekit dfu` + `status` verified against the cabled target Mac (detection + model ID confirmed)
 - [x] **Full restore hardware-verified**: end-to-end erase-restore of an M1 Pro over the FFI succeeded; target booted to Setup Assistant
+- [x] **Obliteration verification hardware-verified**: an erase restore scans the device's `format_effaceable_storage` checkpoint (`result=0`) to confirm the encryption media key was destroyed; the verdict is surfaced (CLI + `Obliteration` event) and persisted to history. Reported on failure too, since the key can be destroyed before a later step fails
+- [ ] **`obliterate` command** (implemented, not yet hardware-tested): patched idevicerestore (`FLAG_OBLITERATE_ONLY`) stops the restore right after the effaceable wipe, leaving the Mac wiped and OS-less — a fast decommissioning wipe
 
 ## 10. Multi-device support & the Device primitive
 - [x] `dfu::Target` selector (`One` / `Ecid`) unifying discovery: `dfu::find(target)` / `dfu::wait(target, timeout)` replace `find_one` / `wait_for_dfu`; ambiguity is an explicit `MultipleDevices` error

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -66,7 +66,7 @@ and linked in. No subprocess, no `brew install idevicerestore`.
 - [x] Hardware: `sudo restorekit dfu` + `status` verified against the cabled target Mac (detection + model ID confirmed)
 - [x] **Full restore hardware-verified**: end-to-end erase-restore of an M1 Pro over the FFI succeeded; target booted to Setup Assistant
 - [x] **Obliteration verification hardware-verified**: an erase restore scans the device's `format_effaceable_storage` checkpoint (`result=0`) to confirm the encryption media key was destroyed; the verdict is surfaced (CLI + `Obliteration` event) and persisted to history. Reported on failure too, since the key can be destroyed before a later step fails
-- [ ] **`obliterate` command** (implemented, not yet hardware-tested): patched idevicerestore (`FLAG_OBLITERATE_ONLY`) stops the restore right after the effaceable wipe, leaving the Mac wiped and OS-less — a fast decommissioning wipe
+- [x] **`obliterate` command hardware-verified**: patched idevicerestore (`FLAG_OBLITERATE_ONLY`) stops the restore right after the effaceable wipe, leaving the Mac wiped and OS-less — a fast decommissioning wipe. Confirmed on an M1 MacBook Pro: the restore halted at `format_effaceable_storage result=0` and skipped the OS-image upload entirely (~34 prep checkpoints, no filesystem upload, vs a full restore)
 
 ## 10. Multi-device support & the Device primitive
 - [x] `dfu::Target` selector (`One` / `Ecid`) unifying discovery: `dfu::find(target)` / `dfu::wait(target, timeout)` replace `find_one` / `wait_for_dfu`; ambiguity is an explicit `MultipleDevices` error

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -74,7 +74,7 @@ into DFU manually (restorekit prints the key-combo instructions), then
 | `download` | Resolve firmware for the detected DFU device (or `--identifier`), download to cache. |
 | `restore` | One-shot erase-restore: trigger DFU entry if needed → wait → download → full erase-restore (`--yes` skips confirmation; `--ipsw`/`--os-version` pin firmware; `--ecid` picks a target when several are in DFU, otherwise an interactive picker). |
 | `revive` | Reinstall firmware without erasing user data (un-brick after a failed update). Same target/firmware flags as `restore`; no erase, so no `--yes`. |
-| `obliterate` | Destroy the encryption (media) key and stop, without reinstalling the OS — the effaceable wipe runs, then the restore halts, leaving the Mac wiped and OS-less. Fast decommissioning wipe; run `restore` afterward to make it usable. Same target/firmware flags as `restore`. |
+| `obliterate` | Destroy the encryption (media) key and stop, without reinstalling the OS — the effaceable wipe runs, then the restore halts, leaving the Mac wiped and OS-less. Fast decommissioning wipe; run `restore` afterward to make it usable. Same target/firmware flags as `restore`. See [obliterate.md](obliterate.md). |
 | `cache` | Show or clear the firmware cache (`--path`, `--clear`). |
 | `setup-driver` | Bind the WinUSB driver so restorekit can reach the target (Windows only). |
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -74,6 +74,7 @@ into DFU manually (restorekit prints the key-combo instructions), then
 | `download` | Resolve firmware for the detected DFU device (or `--identifier`), download to cache. |
 | `restore` | One-shot erase-restore: trigger DFU entry if needed → wait → download → full erase-restore (`--yes` skips confirmation; `--ipsw`/`--os-version` pin firmware; `--ecid` picks a target when several are in DFU, otherwise an interactive picker). |
 | `revive` | Reinstall firmware without erasing user data (un-brick after a failed update). Same target/firmware flags as `restore`; no erase, so no `--yes`. |
+| `obliterate` | Destroy the encryption (media) key and stop, without reinstalling the OS — the effaceable wipe runs, then the restore halts, leaving the Mac wiped and OS-less. Fast decommissioning wipe; run `restore` afterward to make it usable. Same target/firmware flags as `restore`. |
 | `cache` | Show or clear the firmware cache (`--path`, `--clear`). |
 | `setup-driver` | Bind the WinUSB driver so restorekit can reach the target (Windows only). |
 

--- a/docs/restore-attestation.md
+++ b/docs/restore-attestation.md
@@ -1,0 +1,142 @@
+# Restore attestation: what it is, and why restorekit can't (and needn't) do it
+
+This documents an investigation into Apple Silicon **restore attestation** — the
+`RestoreAttestation` step in the DFU restore protocol. Short version: an attested
+restore requires the *host* to prove it's an Apple-account-authenticated station,
+which only Apple's own tooling can do; a normal restore doesn't need it; and it
+was never relevant to verifiable erasure anyway. It's written down so nobody has
+to re-run the whole dead end.
+
+## TL;DR
+
+- A restore attestation involves **two** parties: the **device** attests it's
+  genuine, and the **host** attests it's an authorized restore "station."
+- The device half is doable (idevicerestore can trigger it). The **host half is
+  gated behind Apple's AuthKit + Anisette account infrastructure** (`akd`,
+  `cloudd`), so only Configurator/MobileDevice on an Apple-ID-signed-in Mac can
+  produce it.
+- Restoring **does not require attestation** — restorekit restores fine with it
+  declined, which is what it does.
+- The attestation attests device identity + installed OS/firmware measurements.
+  It is **not** a proof of erasure and is verifiable only by Apple.
+- Net for refurbishment: **no value.** Use the effaceable-wipe checkpoint (see
+  [obliterate.md](obliterate.md)) for verifiable erasure.
+
+## Background
+
+While building verifiable erasure, we noticed the restore protocol has a
+`RestoreAttestation` message that stock idevicerestore explicitly declines
+(`RestoreShouldAttest: false`). We wanted to know what it is and whether it
+could give a stronger, signed proof than the device's self-reported checkpoints.
+
+## The two-party attestation architecture
+
+### 1. Device attestation (BAA)
+
+When the host opts in (`RestoreShouldAttest: true`), the device produces a
+hardware attestation and returns it as `RestoreAttestationState: AttestationIssued`
+with an X.509 cert chain:
+
+- **Leaf**: `CN=<measurement digest>, OU=BAA Certification, O=Apple Inc.`, ~3-day
+  validity. Its Apple OID extensions (`1.2.840.113635.100.8.x`) carry the device
+  identity (ChipID `8103`/M1, ECID), the OS version being installed, and firmware
+  measurements (SEP `rsep`, iBoot `ibss`, etc.).
+- **Chain**: `Basic Attestation System Sub CA1` → `Basic Attestation System Root CA`
+  (Apple's "BAA" — Basic Attestation Authority PKI).
+
+The device fetches this from Apple's `humb.apple.com` **through the host's reverse
+proxy** (the device has no network in restore mode; the ramdisk's
+PurpleReverseProxy tunnels its SOCKS connections out through the host). This half
+works with idevicerestore — we captured a real cert (`~/restorekit-attestation/`).
+
+### 2. Host / "station" attestation (the SCRT)
+
+The device won't commit the recovery-OS **LocalPolicy** on an attested restore
+unless the *host* also presents a valid attestation — a "station-local SCRT"
+(Secure Cryptographic Restore Ticket) rooted in Apple's **`Apple Accessory Host
+Attestation Authority`**. This is the piece idevicerestore doesn't do.
+
+Reading Apple Configurator's `cfgutil` restore via the unified log showed exactly
+how the host produces it:
+
+```
+(MobileDevice) Restore attestation requested because build identity asked for attestation
+(MobileDevice) Restore security attestation: AVAILABLE
+cloudd (AuthKit) authkit/fetch-attestation-data-async
+[com.apple.authkit:signpost] BEGIN FetchAttestation
+akd 'attestationDataForRequestData:completion:'
+akd BEGIN SignAndAttestation enableTelemetry=YES
+cloudd [com.apple.authkit:traffic] Remote Anisette service returned Attestation data
+(MobileDevice) Attestation manifest hash matches
+(MobileDevice) Restore certificate authenticated DFU attestation
+```
+
+So the host attestation is produced by **AuthKit** (`akd`, the Apple-ID daemon,
+and `cloudd`), fetching its data from **Apple's Anisette service** — the same
+per-machine + per-account anti-fraud identity machinery used for Apple-ID/iCloud
+authentication. It is bound to a **signed-in Apple ID** on the host and Apple's
+live Anisette provisioning.
+
+## Why restorekit / idevicerestore can't complete it
+
+We reproduced the failure precisely. With attestation enabled:
+
+1. The device attests fine (fetches its BAA cert via the reverse proxy).
+2. At `macos_create_recovery_local_policy`, the host sends the **identical**,
+   valid, Apple-TSS-signed LocalPolicy it sends on a normal restore (verified by
+   dumping the request — the arguments are byte-for-byte the same three fields).
+3. The device **rejects** it with `result=6 (failed to create recovery os local
+   policy)` — accepted when not attested, rejected when attested.
+
+The rejection isn't about the LocalPolicy contents or any missing protocol field
+(we tried `AttestationUseSCRT` true and false, and enabling the `Provisioning*`
+messages — none change it). The device requires the host's **station attestation**,
+and idevicerestore performs none: no AuthKit, no Anisette, no Apple-ID session.
+
+Making restorekit do it would mean reimplementing Apple-account attestation —
+an Apple-ID login, Apple's private AuthKit attestation APIs, and Anisette
+provisioning (the thing AltServer/SideStore proxy just for basic Apple-ID
+sign-in). That is macOS-host-only, account-gated, version-fragile, and squarely
+inside Apple's authentication infrastructure. It is not a "thread a field
+through" fix; it's a different product. This is an **intentional gate**: only an
+Apple-account-authenticated station may perform an attested restore.
+
+## What restore attestation is actually for
+
+It's a trust / anti-abuse mechanism, not a functional requirement. Requiring
+*both* a genuine device and an authenticated, accountable host lets Apple gate
+security-sensitive restore operations — chiefly **creating the recovery-OS
+LocalPolicy**, which defines boot/ownership/sealing policy. That underpins
+Activation Lock / ownership enforcement, provisioning and MDM/fleet trust, and
+anti-fraud (the Anisette tie-in binds mass operations to real accounts). It's
+about controlling *who may reconfigure a device's security posture*.
+
+## Why it doesn't matter for refurbishment
+
+- **Not required to restore.** restorekit declines attestation and restores fine.
+- **Not required to wipe.** `obliterate`/erase work with zero attestation.
+- **Not a proof of erasure.** The cert attests install + identity + firmware
+  measurements — never "the media key was destroyed" — and it's Apple-only-
+  verifiable and expires in ~3 days.
+
+For verifiable erasure, the real signal is the device's `format_effaceable_storage`
+checkpoint (`result=0`), which restorekit already captures and records. See
+[obliterate.md](obliterate.md).
+
+## Evidence
+
+- `~/restorekit-attestation/` (on the dev machine, not in-repo): the captured
+  device attestation — `cert0.der` (leaf), `cert1.der` (sub CA), `attestation.plist`
+  (the raw `AttestationIssued` message), `cert0.txt` (decoded), and the restore
+  logs.
+- Host-side flow: captured from `cfgutil restore` via
+  `log stream` filtered to the attestation/activation subsystems.
+
+## Conclusion
+
+Restore attestation is Apple's two-party (device + Apple-account-authenticated
+host) trust gate for security-policy creation during restore. It is not
+completable outside Apple's authorized, account-authenticated tooling, and it is
+orthogonal to both restoring and to verifiable erasure. The research patches used
+to probe it (an attestation opt-in and a LocalPolicy-request dump) were removed
+after this investigation; they are recoverable from git history if ever needed.


### PR DESCRIPTION
## What

Three related pieces around destroying a Mac's encryption (media) key during a refurb/decommission:

1. **Verify** an erase restore actually destroyed the key.
2. **Record** the verdict to the history log (CLI + desktop).
3. **A dedicated `obliterate` command** that wipes the key and stops, without reinstalling the OS.

## How the wipe is detected

During an erase an Apple Silicon/T2 device forwards its effaceable-storage wipe to the host as a restore checkpoint:

```
Checkpoint completed id: 0x61F (format_effaceable_storage) result=0
```

`result=0` means the media key was destroyed. The restore log is scanned live and classified: `confirmed`, `failed`, `unconfirmed`, `not_applicable`. Verified end-to-end on a real M1 MacBook Pro.

## Changes

- **Verdict + reporting** — `Obliteration` type + log scanner; emitted as an `Obliteration` progress event and printed by the CLI. Reported on **both** success and failure (the key can be destroyed before a later step fails).
- **History** — new `obliteration` column (migration `003`); verdict persisted; failed-but-wiped restores recorded. Added CLI history writing (it previously only read) with a SQLite-backed `now_rfc3339()` helper. Best-effort — a history write never fails the restore.
- **`obliterate` command** — new `idevicerestore` patch (`0003`) adds `FLAG_OBLITERATE_ONLY`: when set, the restore loop stops via the normal `FLAG_QUIT` path as soon as the effaceable checkpoint completes, before the OS write. Exposed as `Mode::Obliterate` and `restorekit obliterate`, which leaves the Mac wiped and OS-less (a confirmed wipe counts as success even if the truncated restore reports an error).
- **Desktop** — verdict threaded through the job pipeline; sticky against retry downgrades.

## Testing

- Unit tests: scanner (checkpoint + textual), timestamp format, history roundtrip.
- Live-validated the **verify + erase** path on an M1: printed `Encryption key obliterated (verified: … result=0)` and completed.
- Builds with/without the `history` feature; patch `0003` applies cleanly; clippy + `svelte-check` clean.

## Not yet hardware-tested

- The **`obliterate` command** (patch `0003`) has not yet been run on hardware — the early-`FLAG_QUIT` behavior and clean return need a live erase on a test Mac to confirm.
- The failure-path reporting hasn't been re-observed on a live failure (the validation re-run succeeded).