### PR TITLE
Trigger DFU on any Type-C data port, not just the UART-harness port

### DIFF
--- a/crates/restorekit-cli/src/commands/dfu.rs
+++ b/crates/restorekit-cli/src/commands/dfu.rs
@@ -260,6 +260,52 @@ pub fn serial(
     }
 }
 
+/// `restorekit probe-ports` — report which host USB-C ports can accept DFU/VDM
+/// commands. Enters and leaves each port controller's DBMa debug mode; sends no
+/// DFU action, so it's non-destructive (though it can briefly blip a live
+/// peripheral on a port).
+pub fn probe_ports(json: bool) -> Result<()> {
+    let probes = restorekit::dfu::probe_ports(&mut |e| {
+        if !json {
+            emit_stage(json, e)
+        }
+    })?;
+    if json {
+        for p in &probes {
+            println!(
+                "{}",
+                serde_json::json!({
+                    "event": "port_probe",
+                    "rid": p.rid,
+                    "location": p.location,
+                    "connected": p.connected,
+                    "dfu_capable": matches!(&p.dbma, Ok(s) if s == "DBMa"),
+                    "status": p.dbma.as_ref().ok(),
+                    "error": p.dbma.as_ref().err(),
+                })
+            );
+        }
+        return Ok(());
+    }
+    println!("\nHost USB-C ports (DFU/VDM capability):\n");
+    for p in &probes {
+        let loc = p.location.as_deref().unwrap_or("?");
+        let conn = if p.connected {
+            "device attached"
+        } else {
+            "empty"
+        };
+        let verdict = match &p.dbma {
+            Ok(s) if s == "DBMa" => "DFU-capable".to_string(),
+            Ok(s) => format!("reached debug (status {s})"),
+            Err(e) => format!("not capable — {e}"),
+        };
+        println!("  RID {:<2}  {:<12}  {:<16}  {verdict}", p.rid, loc, conn);
+    }
+    println!();
+    Ok(())
+}
+
 /// Ensure a Mac is in DFU mode: return it if already there (with the interactive
 /// picker when several are present and no ECID pins one), otherwise trigger
 /// entry via a dongle or the host and wait. Shared by `restore`.

--- a/crates/restorekit-cli/src/main.rs
+++ b/crates/restorekit-cli/src/main.rs
@@ -39,6 +39,11 @@ enum Command {
     /// Stream the target Mac's debug serial console (Apple Silicon macOS host +
     /// SuperSpeed USB-C cable). Muxes the UART onto the SBU pins like macvdmtool.
     Serial(TargetArgs),
+    /// Probe which host USB-C ports can accept DFU/VDM commands by entering and
+    /// leaving each port controller's debug mode (Apple Silicon macOS, root).
+    /// Diagnostic — sends no DFU action. Hidden.
+    #[command(hide = true)]
+    ProbePorts,
     /// Resolve and download firmware for the detected (or specified) Mac.
     Download {
         /// Model identifier (e.g. MacBookPro17,1). Defaults to the DFU device.
@@ -298,6 +303,7 @@ fn main() {
         Command::Dfu(t) => commands::dfu::enter(cli.json, t.dongle, t.ecid, t.port),
         Command::Reboot(t) => commands::dfu::reboot(cli.json, t.dongle, t.ecid, t.port),
         Command::Serial(t) => commands::dfu::serial(cli.json, t.dongle, t.ecid, t.port),
+        Command::ProbePorts => commands::dfu::probe_ports(cli.json),
         Command::Download {
             identifier,
             os_version,

--- a/crates/restorekit/src/dfu/mod.rs
+++ b/crates/restorekit/src/dfu/mod.rs
@@ -51,6 +51,39 @@ pub fn ports() -> Vec<HostPortInfo> {
     }
 }
 
+/// One host USB-C port's DFU/VDM capability-probe result (see [`probe_ports`]).
+#[derive(Debug, Clone)]
+pub struct PortProbe {
+    /// The AppleHPM `RID` addressing this port — the value `--port` takes.
+    pub rid: i32,
+    /// Physical location label from the firmware (e.g. "left-back"), if any.
+    pub location: Option<String>,
+    /// Whether a USB-C partner is attached on this port right now.
+    pub connected: bool,
+    /// `Ok("DBMa")` when the controller entered debug mode — i.e. this port
+    /// accepts the DFU/VDM path. `Ok(other)` if it landed elsewhere, `Err` with
+    /// the reason it couldn't.
+    pub dbma: std::result::Result<String, String>,
+}
+
+/// Probe every host USB-C port for whether it can accept DFU/VDM commands, by
+/// entering and immediately leaving the port controller's DBMa debug mode. Sends
+/// no DFU action, so it's non-destructive — but entering debug mode can briefly
+/// blip a live peripheral on a port. Apple Silicon macOS only; errors elsewhere.
+pub fn probe_ports(progress: crate::progress::ProgressFn) -> crate::error::Result<Vec<PortProbe>> {
+    #[cfg(target_os = "macos")]
+    {
+        vdm::probe_ports(progress)
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = progress;
+        Err(crate::error::Error::UnsupportedHost(
+            "probing USB-C ports needs an Apple Silicon Mac".into(),
+        ))
+    }
+}
+
 /// Human label of the host's DFU-capable port (e.g. "left-back"), if the host
 /// can trigger DFU and the port topology is known. `None` on hosts that can't
 /// trigger DFU or where the label couldn't be read.

--- a/crates/restorekit/src/dfu/port.rs
+++ b/crates/restorekit/src/dfu/port.rs
@@ -174,10 +174,12 @@ unsafe fn for_each_service(class: &str, mut f: impl FnMut(IoObject)) {
     IOObjectRelease(iter);
 }
 
-/// RIDs of the HPM controllers that can send DFU VDMs, from `uart-hpm-rids`
-/// (a bitmask). Falls back to `[0]` when the property is absent — the port
-/// index [`vdm`](super::vdm) historically hardcoded.
-pub(crate) fn dfu_capable_rids() -> Vec<i32> {
+/// The **default** port RID(s) to drive when no `--port`/`--ecid` pins one, from
+/// `uart-hpm-rids` (a bitmask). *Every* data port can trigger DFU (see
+/// [`HostPort::dfu`]); this is just the sensible default — the UART/debug-harness
+/// port the tool historically used. Falls back to `[0]` when the property is
+/// absent (the RID `vdm` hardcoded).
+pub(crate) fn default_dfu_rids() -> Vec<i32> {
     read_uart_hpm_rids().unwrap_or_else(|| vec![0])
 }
 
@@ -213,6 +215,13 @@ fn read_uart_hpm_rids() -> Option<Vec<i32>> {
 struct HostPort {
     base: u32,
     location: Option<String>,
+    /// Whether DFU/VDM can be triggered on this port. Every Type-C **data** port
+    /// can — the DFU trigger is a USB-PD Vendor Defined Message and any port's
+    /// HPM controller sends it (verified by DBMa-probing each RID). This is
+    /// always true for `host_ports`, which are exactly the HPM controllers backed
+    /// by a USB data controller; power-only PD controllers (e.g. MagSafe) have no
+    /// USB controller, so they never make it into this list. (`uart-hpm-rids`,
+    /// which older code gated on here, is only the serial/UART-harness subset.)
     dfu: bool,
     /// The AppleHPM `RID` that drives this port's DFU/debug VDMs.
     rid: i32,
@@ -226,14 +235,17 @@ fn host_ports() -> &'static [HostPort] {
 }
 
 fn resolve_host_ports() -> Vec<HostPort> {
-    let dfu_rids = dfu_capable_rids();
     unsafe {
-        // Each Type-C controller → (port-number, location, is-dfu, rid).
+        // Each Type-C controller → (port-number, location, is-dfu, rid). Every
+        // controller that reaches here is later matched to a USB data controller
+        // (below), and every such data port can trigger DFU — so `dfu` is always
+        // true. (Power-only PD controllers like MagSafe have no USB controller
+        // and get dropped in the match, never appearing as a port.)
         let mut controllers: Vec<(u32, Option<String>, bool, i32)> = Vec::new();
         for_each_service("AppleHPM", |hpm| {
             if let (Some(rid), Some(pn)) = (prop_u32(hpm, "RID"), search_u32(hpm, "port-number")) {
                 let location = search_string(hpm, "port-location");
-                controllers.push((pn, location, dfu_rids.contains(&(rid as i32)), rid as i32));
+                controllers.push((pn, location, true, rid as i32));
             }
         });
         // Match each to the USB controller with the same port-number → its
@@ -269,6 +281,22 @@ pub(crate) fn all_ports() -> Vec<super::HostPortInfo> {
             dfu: p.dfu,
         })
         .collect()
+}
+
+/// Every `AppleHPM` controller as `(RID, port-location)`, unfiltered by the
+/// `uart-hpm-rids` UART-harness mask — the full set of port controllers the VDM
+/// probe can open and test for the debug/DFU path.
+pub(crate) fn all_hpm_ports() -> Vec<(i32, Option<String>)> {
+    let mut out = Vec::new();
+    unsafe {
+        for_each_service("AppleHPM", |hpm| {
+            if let Some(rid) = prop_u32(hpm, "RID") {
+                out.push((rid as i32, search_string(hpm, "port-location")));
+            }
+        });
+    }
+    out.sort_by_key(|&(rid, _)| rid);
+    out
 }
 
 /// The RID of the DFU-capable port the USB device with this serial is cabled to,
@@ -338,7 +366,7 @@ mod tests {
     #[test]
     #[ignore = "reads live host IORegistry"]
     fn port_topology() {
-        eprintln!("dfu_capable_rids: {:?}", super::dfu_capable_rids());
+        eprintln!("default_dfu_rids: {:?}", super::default_dfu_rids());
         for p in super::host_ports() {
             eprintln!(
                 "port: base={:#010x} location={:?} dfu={}",

--- a/crates/restorekit/src/dfu/vdm.rs
+++ b/crates/restorekit/src/dfu/vdm.rs
@@ -327,6 +327,30 @@ impl Hpm {
         }
         Ok(())
     }
+
+    /// Capability probe: whether a partner is attached (register 0x3f bit0) and
+    /// whether the controller enters DBMa (debug/VDM) mode — *without* the
+    /// connection precondition [`enter_dbma`](Self::enter_dbma) enforces, and
+    /// without sending any DFU action. `Drop` leaves DBMa, so it's
+    /// non-destructive.
+    fn probe(&self, key: u32) -> (bool, Result<String>) {
+        let connected = self
+            .read_register(0x3f)
+            .map(|r| r[0] & 1 != 0)
+            .unwrap_or(false);
+        let dbma = (|| -> Result<String> {
+            let status = self.read_status_string(0x03)?;
+            if status == "DBMa" {
+                return Ok(status);
+            }
+            self.unlock(key)?;
+            if self.command(fourcc(b"DBMa"), &[0x01])? != 0 {
+                return Err(Error::Vdm("DBMa command NAK".into()));
+            }
+            self.read_status_string(0x03)
+        })();
+        (connected, dbma)
+    }
 }
 
 impl Drop for Hpm {
@@ -407,7 +431,7 @@ fn resolve_rid(target: &DfuTarget) -> Result<Option<i32>> {
 /// [`super::port`]) and we pick the first matching controller, falling back to
 /// `RID == 0` when that property is absent.
 fn find_device(target_rid: Option<i32>) -> Result<Hpm> {
-    let dfu_rids = super::port::dfu_capable_rids();
+    let dfu_rids = super::port::default_dfu_rids();
     let wanted = |rid: i32| match target_rid {
         Some(t) => rid == t,
         None => dfu_rids.contains(&rid),
@@ -526,6 +550,42 @@ fn connect(target: &DfuTarget, progress: &mut dyn FnMut(Event)) -> Result<Hpm> {
 
 /// Reboot the cabled target Mac into DFU mode. `target` selects which port to
 /// drive when the host has several DFU-capable ports (see [`DfuTarget`]).
+/// Probe every host HPM controller for DFU/VDM capability by entering (and, via
+/// `Drop`, immediately leaving) DBMa debug mode. Sends no DFU action. Backs
+/// [`super::probe_ports`].
+pub fn probe_ports(progress: ProgressFn) -> Result<Vec<super::PortProbe>> {
+    preflight()?;
+    let (key, mac_type) = unlock_key()?;
+    progress(Event::DfuTriggerStage {
+        stage: format!("host: {mac_type}"),
+    });
+    let mut out = Vec::new();
+    for (rid, location) in super::port::all_hpm_ports() {
+        progress(Event::DfuTriggerStage {
+            stage: format!("probing RID {rid}"),
+        });
+        let probe = match find_device(Some(rid)) {
+            Ok(hpm) => {
+                let (connected, dbma) = hpm.probe(key);
+                super::PortProbe {
+                    rid,
+                    location,
+                    connected,
+                    dbma: dbma.map_err(|e| e.to_string()),
+                }
+            }
+            Err(e) => super::PortProbe {
+                rid,
+                location,
+                connected: false,
+                dbma: Err(e.to_string()),
+            },
+        };
+        out.push(probe);
+    }
+    Ok(out)
+}
+
 pub fn enter_dfu(target: &DfuTarget, progress: ProgressFn) -> Result<()> {
     let hpm = connect(target, progress)?;
     progress(Event::DfuTriggerStage {


### PR DESCRIPTION
restorekit gated DFU-capable ports on the `uart-hpm-rids` device-tree property, but that's the serial/UART debug-harness subset (often a single port), not the set of ports that can send a DFU VDM. Every USB-C data port's HPM controller can send the Apple vendor DFU/reboot Vendor Defined Message — verified by driving each port controller into DBMa debug mode. So a target cabled to any port other than the harness one was invisible to `--port` and to detection.

Mark every host port DFU-capable: `host_ports()` entries are exactly the HPM controllers backed by a USB data controller, and all of those can trigger DFU. Power-only PD controllers (e.g. MagSafe) have no USB controller, so they're already excluded and won't resolve as `--port` targets. `uart-hpm-rids` now only selects the Auto/default port and gates the serial console; rename `dfu_capable_rids` to `default_dfu_rids` to match.

Also add a hidden `probe-ports` command that enters and leaves each port controller's DBMa mode and reports which ports accept the DFU/VDM path — the non-destructive diagnostic used to confirm the above.