### PR TITLE
Declare 100 mA in the dongle's USB configuration descriptor

### DIFF
--- a/crates/dongle-lite-fw/src/main.rs
+++ b/crates/dongle-lite-fw/src/main.rs
@@ -437,7 +437,13 @@ async fn main(_spawner: Spawner) {
         proto::PRODUCT_LITE
     });
     config.serial_number = Some(serial);
-    config.max_power = 250;
+    // The MCU sits behind our own CH334F, which is strapped bus-powered
+    // (PSELF to GND), so the host only budgets 100 mA per downstream port.
+    // Ask for more and macOS refuses to set the configuration at all: the
+    // device enumerates with no interfaces and `restorekit list` can't see it.
+    // 100 mA covers this function — the hub and the target-VBUS switch draw
+    // from +5V upstream of this port, not through it.
+    config.max_power = 100;
     config.max_packet_size_0 = 64;
     // Composite device with IADs.
     config.device_class = 0xEF;

--- a/scripts/bump-fw-version.sh
+++ b/scripts/bump-fw-version.sh
@@ -47,4 +47,4 @@ echo "  committed: chore(release): bump dongle firmware to $new"
 
 echo
 echo "done. next:"
-echo "  git tag dongle-lite-fw-v$new && git push origin main dongle-lite-fw-v$new"
+echo "  git tag dongle-lite-v$new && git push origin main dongle-lite-v$new"


### PR DESCRIPTION
The MCU sits behind the board's own hub, which is strapped bus-powered (CH334F `PSELF` to GND), so the host may only promise one unit load — 100 mA — to each downstream port. The firmware declared 250 mA, copied from the whole-board budget at J1.

macOS doesn't degrade gracefully when a configuration exceeds the port budget: it refuses `SET_CONFIGURATION` outright and records `kUSBFailedRequestedPower = 250`. The device stays in Address state, so IOKit publishes no `IOUSBHostInterface` children, `nusb` reports an empty interface list, and `dongle::list()` skips the device for lacking a vendor-class interface. Net effect: the dongle showed up correctly in `cyme`/`ioreg` (device descriptors are read before configuration) but `restorekit list` printed nothing at all.

100 mA covers this function — RP2350, FUSB302, two level shifters, two LEDs. The hub itself and the AP22653 target VBUS switch draw from `+5V` upstream of this port, so they were never in this field's scope. One unit load is also the floor any port must supply, so this configures behind any hub on any host.

Verified on hardware: the dongle enumerates with its vendor interface and `restorekit dongle list` sees it again.