### PR TITLE
Build RP2350 UF2s without picotool

### DIFF
--- a/.github/workflows/release-fw.yml
+++ b/.github/workflows/release-fw.yml
@@ -39,11 +39,6 @@ jobs:
           rustup target add thumbv8m.main-none-eabihf
           cargo install flip-link cargo-binutils --locked
 
-      # picotool stamps the rp2350-arm-s UF2 family id (elf2uf2-rs only knows
-      # RP2040). Packaged in Ubuntu 24.04 universe.
-      - name: Install picotool
-        run: sudo apt-get update && sudo apt-get install -y picotool
-
       - name: Build bootloader
         run: cd crates/dongle-lite-boot && cargo build --release --locked
 
@@ -54,14 +49,14 @@ jobs:
           # image; on RP2350 there's no .boot2.
           ( cd crates/dongle-lite-boot && cargo objcopy --release -- -O binary target/dongle-lite-boot.bin )
           boot=crates/dongle-lite-boot/target/dongle-lite-boot
-          picotool uf2 convert "$boot.bin" -t bin -o 0x10000000 --family rp2350-arm-s "$boot.uf2"
+          node scripts/bin2uf2.mjs --base 0x10000000 --family rp2350-arm-s "$boot.bin" "$boot.uf2"
           for model in lite pro; do
             features=""
             [ "$model" = pro ] && features="--features pro"
             ( cd crates/dongle-lite-fw && \
               cargo objcopy --release --locked $features -- -O binary "target/dongle-$model-fw.bin" )
             fw=crates/dongle-lite-fw/target/dongle-$model-fw
-            picotool uf2 convert "$fw.bin" -t bin -o 0x10007000 --family rp2350-arm-s "$fw.uf2"
+            node scripts/bin2uf2.mjs --base 0x10007000 --family rp2350-arm-s "$fw.bin" "$fw.uf2"
             node scripts/merge-uf2.mjs --fill 0x10006000:4096 \
                 "$boot.uf2" "$fw.uf2" \
                 "crates/dongle-lite-fw/target/dongle-$model-full.uf2"

--- a/justfile
+++ b/justfile
@@ -8,8 +8,9 @@ install:
     rustup target add thumbv8m.main-none-eabihf
     rustup component add llvm-tools
     cargo install flip-link cargo-binutils
-    # RP2350 UF2s are built with picotool (elf2uf2-rs only knows the RP2040
-    # family id): `brew install picotool` (macOS) / `apt install picotool`.
+    # picotool is optional: `just fw-flash-full` prefers it for verified
+    # flashing over PICOBOOT, but falls back to copying the UF2 to the bootrom
+    # drive. `brew install picotool` (macOS); not packaged before Ubuntu 25.04.
 
 # Release the software (bump + tag via CI; kind: patch|minor|major)
 release kind="patch": (_dispatch "bump-release.yml" kind)
@@ -87,20 +88,17 @@ fw-update: fw-build
 fw-flash-full: fw-build
     #!/usr/bin/env bash
     set -euo pipefail
-    if ! command -v picotool > /dev/null; then
-        echo "error: picotool is required to build RP2350 UF2s — brew install picotool" >&2
-        exit 1
-    fi
     {{bootsel_kick}}
     # RP2350 UF2s: objcopy each image to a raw .bin at its flash offset, then
-    # let picotool stamp the rp2350-arm-s family id (elf2uf2-rs only knows
-    # RP2040, and picotool's ELF path trips over the app's zero-fill BSS).
+    # stamp the rp2350-arm-s family id (elf2uf2-rs only knows RP2040, and
+    # picotool's ELF path trips over the app's zero-fill BSS). Same converter
+    # release-fw.yml uses, so the bench flashes what CI publishes.
     boot=crates/dongle-lite-boot/target/dongle-lite-boot
     fw=crates/dongle-lite-fw/target/dongle-lite-fw
     ( cd crates/dongle-lite-boot && cargo objcopy --release -- -O binary target/dongle-lite-boot.bin )
     ( cd crates/dongle-lite-fw   && cargo objcopy --release -- -O binary target/dongle-lite-fw.bin )
-    picotool uf2 convert "$boot.bin" -t bin -o 0x10000000 --family rp2350-arm-s "$boot.uf2"
-    picotool uf2 convert "$fw.bin"   -t bin -o 0x10007000 --family rp2350-arm-s "$fw.uf2"
+    node scripts/bin2uf2.mjs --base 0x10000000 --family rp2350-arm-s "$boot.bin" "$boot.uf2"
+    node scripts/bin2uf2.mjs --base 0x10007000 --family rp2350-arm-s "$fw.bin" "$fw.uf2"
     # --fill wipes the bootloader state sector (see dongle-lite-boot/memory.x):
     # leftover bytes there from older firmware can read as a bogus swap state.
     node scripts/merge-uf2.mjs --fill 0x10006000:4096 \

--- a/scripts/bin2uf2.mjs
+++ b/scripts/bin2uf2.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+// Convert a raw binary to UF2: bin2uf2.mjs --base ADDR --family NAME IN.bin OUT.uf2
+//
+// Replaces `picotool uf2 convert -t bin`, which we can't rely on in CI:
+// picotool ships no prebuilt binaries and isn't packaged before Ubuntu 25.04.
+// Verified byte-identical to `picotool uf2 convert` for both images we ship
+// (bootloader at 0x10000000, app at 0x10007000).
+//
+// elf2uf2-rs isn't an option either — it only knows the RP2040 family id, and
+// the RP2350 bootrom ignores blocks stamped with the wrong one.
+
+import { readFileSync, writeFileSync } from "node:fs";
+
+const UF2_MAGIC0 = 0x0a324655;
+const UF2_MAGIC1 = 0x9e5d5157;
+const UF2_MAGIC_END = 0x0ab16f30;
+const UF2_FLAG_FAMILY_ID = 0x2000;
+const PAYLOAD = 256;
+
+// picotool's family names (see its uf2.h). Only the ones we target.
+const FAMILIES = {
+  rp2040: 0xe48bff56,
+  absolute: 0xe48bff57,
+  data: 0xe48bff58,
+  "rp2350-arm-s": 0xe48bff59,
+  "rp2350-riscv": 0xe48bff5a,
+  "rp2350-arm-ns": 0xe48bff5b,
+};
+
+const die = (msg) => {
+  console.error(msg);
+  process.exit(1);
+};
+
+const args = process.argv.slice(2);
+const take = (flag) => {
+  const i = args.indexOf(flag);
+  if (i === -1) return undefined;
+  const [value] = args.splice(i, 2).slice(1);
+  return value;
+};
+
+const baseArg = take("--base");
+const familyArg = take("--family");
+if (args.length !== 2) {
+  die("usage: bin2uf2.mjs --base ADDR --family NAME IN.bin OUT.uf2");
+}
+const [input, out] = args;
+
+const base = Number(baseArg);
+if (!Number.isInteger(base) || base < 0) {
+  die(`--base must be an address (got '${baseArg}')`);
+}
+const family = FAMILIES[familyArg];
+if (family === undefined) {
+  die(`--family must be one of ${Object.keys(FAMILIES).join(", ")} (got '${familyArg}')`);
+}
+
+const data = readFileSync(input);
+if (data.length === 0) {
+  die(`${input}: empty`);
+}
+
+// A short final chunk is zero-padded to a full 256-byte payload rather than
+// given a smaller payloadSize: that's what picotool emits, and the bootrom
+// writes whole flash pages anyway.
+const numBlocks = Math.ceil(data.length / PAYLOAD);
+const uf2 = Buffer.alloc(numBlocks * 512);
+for (let i = 0; i < numBlocks; i++) {
+  const block = uf2.subarray(i * 512, (i + 1) * 512);
+  block.writeUInt32LE(UF2_MAGIC0, 0);
+  block.writeUInt32LE(UF2_MAGIC1, 4);
+  block.writeUInt32LE(UF2_FLAG_FAMILY_ID, 8);
+  block.writeUInt32LE(base + i * PAYLOAD, 12);
+  block.writeUInt32LE(PAYLOAD, 16);
+  block.writeUInt32LE(i, 20);
+  block.writeUInt32LE(numBlocks, 24);
+  block.writeUInt32LE(family, 28);
+  data.copy(block, 32, i * PAYLOAD, Math.min((i + 1) * PAYLOAD, data.length));
+  block.writeUInt32LE(UF2_MAGIC_END, 508);
+}
+writeFileSync(out, uf2);
+console.log(`${out}: ${numBlocks} blocks from ${input}`);


### PR DESCRIPTION
`release-fw.yml` installed picotool with `apt-get install -y picotool`, but picotool isn't packaged before Ubuntu 25.04 and upstream ships no prebuilt binaries — only source tarballs. The job failed at `E: Unable to locate package picotool` before building a single asset ([run 30685191648](https://github.com/fcjr/restorekit/actions/runs/30685191648)).

The step had never actually executed before: `dongle-lite-v0.1.1` was the first tag matching the workflow's trigger.

Instead of building picotool from source in CI (needs cmake, libusb, and the pico-sdk), this adds `scripts/bin2uf2.mjs` — same hand-rolled UF2 style as the existing `scripts/merge-uf2.mjs`, which already writes UF2 block headers including the family id.

Verification: converting the bootloader (`0x10000000`) and app (`0x10007000`) images produces output **byte-identical** to `picotool uf2 convert` on the same `.bin` files. The full CI asset build was dry-run locally under bash — all four release assets (`dongle-{lite,pro}-fw.bin`, `dongle-{lite,pro}-full.uf2`) build, and the two models stay distinct (`DL-` vs `DP-` serial prefixes).

`just fw-flash-full` now uses the same converter, so the bench flashes what CI publishes. picotool remains optional there for verified PICOBOOT flashing, with the existing drive-copy fallback — the recipe no longer hard-fails when it's absent.